### PR TITLE
feat: refactor primary brand into an option

### DIFF
--- a/includes/class-taxonomy.php
+++ b/includes/class-taxonomy.php
@@ -38,7 +38,7 @@ class Taxonomy {
 	 *
 	 * @var string
 	 */
-	const PRIMARY_OPTION_NAME = 'primary_brand';
+	const PRIMARY_OPTION_NAME = 'newspack_primary_brand';
 
 	/**
 	 * The current brand, determined depending on the context on WP initiazliation.

--- a/includes/options/class-primary-brand.php
+++ b/includes/options/class-primary-brand.php
@@ -10,7 +10,7 @@ namespace Newspack_Multibranded_Site\Options;
 use Newspack_Multibranded_Site\Taxonomy;
 
 /**
- * Newspack Multi-branded site term meta parent class
+ * Newspack Multi-branded site Primary Brand option
  */
 abstract class Primary_Brand {
 

--- a/includes/options/class-primary-brand.php
+++ b/includes/options/class-primary-brand.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Newspack Multi-branded site term meta parent class.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Multibranded_Site\Options;
+
+use Newspack_Multibranded_Site\Taxonomy;
+
+/**
+ * Newspack Multi-branded site term meta parent class
+ */
+abstract class Primary_Brand {
+
+	/**
+	 * Initializes the Meta
+	 */
+	public static function init() {
+		self::register_option();
+	}
+
+	/**
+	 * Register the tem meta
+	 *
+	 * @return void
+	 */
+	public static function register_option() {
+		$params = [
+			'description'  => static::get_description(),
+			'show_in_rest' => [
+				'schema' => static::get_schema(),
+			],
+		];
+
+		register_setting(
+			Taxonomy::SLUG,
+			static::get_key(),
+			$params
+		);
+	}
+
+	/**
+	 * Gets the meta key
+	 *
+	 * @return string
+	 */
+	public static function get_key() {
+		return Taxonomy::PRIMARY_OPTION_NAME;
+	}
+
+	/**
+	 * Gets the meta description
+	 *
+	 * @return string
+	 */
+	public static function get_description() {
+		return __( 'The primary brand for the site', 'newspack-multibranded-site' );
+	}
+
+	/**
+	 * Gets the meta schema
+	 *
+	 * @return array
+	 */
+	public static function get_schema() {
+		return [
+			'type' => 'integer',
+		];
+	}
+
+}

--- a/tests/unit-tests/test-rest-primary-brand.php
+++ b/tests/unit-tests/test-rest-primary-brand.php
@@ -4,7 +4,7 @@ use PHPUnit\Framework\TestCase;
 use Newspack_Multibranded_Site\Taxonomy;
 
 /**
- * Tests editing the Url metadata from the rest api.
+ * Tests editing the Primary brand option from the rest api.
  */
 class Test_Rest_Primary_Brand extends WP_UnitTestCase {
 

--- a/tests/unit-tests/test-rest-primary-brand.php
+++ b/tests/unit-tests/test-rest-primary-brand.php
@@ -1,0 +1,136 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+use PHPUnit\Framework\TestCase;
+use Newspack_Multibranded_Site\Taxonomy;
+
+/**
+ * Tests editing the Url metadata from the rest api.
+ */
+class Test_Rest_Primary_Brand extends WP_UnitTestCase {
+
+	/**
+	 * REST Server object.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * The current user id.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * The secondary user id.
+	 *
+	 * @var int
+	 */
+	private $secondary_user_id;
+
+	/**
+	 * A testing brand term.
+	 *
+	 * @var WP_Term
+	 */
+	private $term1;
+
+	/**
+	 * Setting up the test.
+	 *
+	 * @before
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// See https://core.trac.wordpress.org/ticket/48300.
+		do_action( 'init' );
+
+		global $wp_rest_server;
+
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		do_action( 'rest_api_init' );
+
+		$this->user_id = $this->factory->user->create_and_get(
+			array(
+				'role' => 'administrator',
+			)
+		);
+
+		$this->secondary_user_id = $this->factory->user->create_and_get(
+			array(
+				'role' => 'editor',
+			)
+		);
+
+		$this->term1 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+	}
+
+	/**
+	 * Dispatches a POST request to edit the site option
+	 *
+	 * @param string $value The new meta value.
+	 * @return WP_REST_Response
+	 */
+	private function distpatch_request_to_edit_the_option( $value ) {
+		$endpoint = '/wp/v2/settings';
+
+		$request = new WP_REST_Request(
+			'POST',
+			$endpoint
+		);
+
+		$request->set_header( 'content-type', 'application/json' );
+
+		$request->set_body(
+			wp_json_encode(
+				[
+					Taxonomy::PRIMARY_OPTION_NAME => $value,
+				]
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		return $response;
+	}
+
+	/**
+	 * Test editing without permissions
+	 */
+	public function test_unauthorized() {
+		wp_set_current_user( 0 );
+		$response = $this->distpatch_request_to_edit_the_option( 123 );
+		$this->assertSame( 401, $response->get_status() );
+
+		wp_set_current_user( $this->secondary_user_id->ID );
+		$response = $this->distpatch_request_to_edit_the_option( 123 );
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * Test setting a valid value
+	 */
+	public function test_valid_input() {
+		wp_set_current_user( $this->user_id->ID );
+		$response = $this->distpatch_request_to_edit_the_option( 123 );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 123, $data[ Taxonomy::PRIMARY_OPTION_NAME ] );
+	}
+
+	/**
+	 * Test setting an invalid value
+	 */
+	public function test_invalid_input() {
+		wp_set_current_user( $this->user_id->ID );
+		$response = $this->distpatch_request_to_edit_the_option( 'invalid' );
+		$data     = $response->get_data();
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+}

--- a/tests/unit-tests/test-taxonomy.php
+++ b/tests/unit-tests/test-taxonomy.php
@@ -30,40 +30,15 @@ class TestTaxonomy extends WP_UnitTestCase {
 		$primary = Taxonomy::get_primary();
 		$this->assertSame( $term1->term_id, $primary->term_id, 'If no primary was set, should return the first' );
 
-		add_term_meta( $term3->term_id, Taxonomy::PRIMARY_META_KEY, true );
+		Taxonomy::set_primary( $term3->term_id );
 
 		$primary = Taxonomy::get_primary();
 		$this->assertSame( $term3->term_id, $primary->term_id );
 
-		add_term_meta( $term2->term_id, Taxonomy::PRIMARY_META_KEY, true );
+		Taxonomy::set_primary( $term2->term_id );
 
 		$primary = Taxonomy::get_primary();
 		$this->assertSame( $term2->term_id, $primary->term_id );
-	}
-
-	/**
-	 * Test reset primary on setting a new primary.
-	 */
-	public function test_reset_primary_on_add() {
-		$term1 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
-		$term2 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
-		$term3 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
-
-		global $wpdb;
-		$query = $wpdb->prepare( "SELECT count(term_id) FROM $wpdb->termmeta WHERE meta_key = %s", Taxonomy::PRIMARY_META_KEY );
-
-		// phpcs:disable
-		$this->assertSame( 0, (int) $wpdb->get_var( $query ), 'No primary term should be set' );
-
-		add_term_meta( $term1->term_id, Taxonomy::PRIMARY_META_KEY, true );
-		$this->assertSame( 1, (int) $wpdb->get_var( $query ), 'One primary term should be set' );
-
-		add_term_meta( $term2->term_id, Taxonomy::PRIMARY_META_KEY, true );
-		$this->assertSame( 1, (int) $wpdb->get_var( $query ), 'One primary term should be set' );
-
-		add_term_meta( $term3->term_id, Taxonomy::PRIMARY_META_KEY, true );
-		$this->assertSame( 1, (int) $wpdb->get_var( $query ), 'One primary term should be set' );
-		// phpcs:enable
 	}
 
 	/**


### PR DESCRIPTION
Zak,

Added this as a PR so you can see the changes.

Now you should be able to change this options via v2/settings/newspack_primary_brand (see the tests)