### PR TITLE
feat: Add custom logo option

### DIFF
--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -21,6 +21,7 @@ class Initializer {
 
 		Customizations\Url::init();
 		Customizations\ShowPageOnFront::init();
+		Customizations\Logo::init();
 	}
 
 }

--- a/includes/class-taxonomy.php
+++ b/includes/class-taxonomy.php
@@ -153,6 +153,7 @@ class Taxonomy {
 		Meta\Url::init();
 		Meta\ShowPageOnFront::init();
 		Meta\Post_Primary_Brand::init();
+		Meta\Logo::init();
 	}
 
 	/**

--- a/includes/customizations/class-logo.php
+++ b/includes/customizations/class-logo.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Newspack Multi-branded site taxonomy.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Multibranded_Site\Customizations;
+
+use Newspack_Multibranded_Site\Meta\Logo as Logo_Meta;
+use Newspack_Multibranded_Site\Taxonomy;
+
+/**
+ * Class to handle the Logo Customization
+ */
+class Logo {
+
+	/**
+	 * Initializes
+	 */
+	public static function init() {
+		add_filter( 'theme_mod_custom_logo', [ __CLASS__, 'filter_logo' ] );
+	}
+
+	/**
+	 * Filters the logo
+	 *
+	 * @param int $logo_id The logo ID.
+	 * @return int
+	 */
+	public static function filter_logo( $logo_id ) {
+		$brand = Taxonomy::get_current();
+		if ( ! $brand ) {
+			return $logo_id;
+		}
+		$custom_logo = get_term_meta( $brand->term_id, Logo_Meta::get_key(), true );
+		if ( $custom_logo ) {
+			$logo_id = $custom_logo;
+		}
+		return $logo_id;
+	}
+
+}

--- a/includes/meta/class-logo.php
+++ b/includes/meta/class-logo.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Newspack Multi-branded site taxonomy.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Multibranded_Site\Meta;
+
+use Newspack_Multibranded_Site\Meta;
+
+/**
+ * Class to handle the Logo Meta
+ */
+class Logo extends Meta {
+
+	/**
+	 * Gets the meta key
+	 *
+	 * @return string
+	 */
+	public static function get_key() {
+		return '_logo';
+	}
+
+	/**
+	 * Gets the meta description
+	 *
+	 * @return string
+	 */
+	public static function get_description() {
+		return __( 'The ID of the attachment to be used as a logo for this brand', 'newspack-multibranded-site' );
+	}
+
+	/**
+	 * Gets the meta schema
+	 *
+	 * @return array
+	 */
+	public static function get_schema() {
+		return array(
+			'type'     => 'integer',
+			'nullable' => true,
+		);
+	}
+
+}

--- a/tests/unit-tests/test-customization-logo.php
+++ b/tests/unit-tests/test-customization-logo.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Class TestLogoCustomization
+ *
+ * @package Newspack_Multibranded_Site
+ */
+
+use Newspack_Multibranded_Site\Taxonomy;
+use Newspack_Multibranded_Site\Meta\Logo;
+
+/**
+ * Test the Logo filter.
+ */
+class TestLogoCustomization extends WP_UnitTestCase {
+
+	/**
+	 * Tests get current brand and determine current brand methods
+	 */
+	public function test_filter_logo() {
+		$term_without_custom_logo = $this->factory->term->create_and_get( [ 'taxonomy' => Taxonomy::SLUG ] );
+		$term_with_custom_logo    = $this->factory->term->create_and_get( [ 'taxonomy' => Taxonomy::SLUG ] );
+		add_term_meta( $term_with_custom_logo->term_id, Logo::get_key(), 123 );
+
+		Taxonomy::set_primary( $term_without_custom_logo );
+		$this->assertSame( false, get_theme_mod( 'custom_logo' ) );
+
+		Taxonomy::set_primary( $term_with_custom_logo );
+		$this->go_to( '/' ); // Resets the current brand.
+		$this->assertSame( '123', get_theme_mod( 'custom_logo' ) );
+	}
+}

--- a/tests/unit-tests/test-rest-logo.php
+++ b/tests/unit-tests/test-rest-logo.php
@@ -1,0 +1,139 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+use PHPUnit\Framework\TestCase;
+use Newspack_Multibranded_Site\Taxonomy;
+use Newspack_Multibranded_Site\Meta\Logo;
+
+/**
+ * Tests editing the Logo metadata from the rest api.
+ */
+class Test_Rest_Logo extends WP_UnitTestCase {
+
+	/**
+	 * REST Server object.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * The current user id.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * The secondary user id.
+	 *
+	 * @var int
+	 */
+	private $secondary_user_id;
+
+	/**
+	 * A testing brand term.
+	 *
+	 * @var WP_Term
+	 */
+	private $term1;
+
+	/**
+	 * Setting up the test.
+	 *
+	 * @before
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// See https://core.trac.wordpress.org/ticket/48300.
+		do_action( 'init' );
+
+		global $wp_rest_server;
+
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		do_action( 'rest_api_init' );
+
+		$this->user_id = $this->factory->user->create_and_get(
+			array(
+				'role' => 'administrator',
+			)
+		);
+
+		$this->secondary_user_id = $this->factory->user->create_and_get(
+			array(
+				'role' => 'editor',
+			)
+		);
+
+		$this->term1 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+	}
+
+	/**
+	 * Dispatches a POST request to edit the term metadata
+	 *
+	 * @param string $value The new meta value.
+	 * @return WP_REST_Response
+	 */
+	private function distpatch_request_to_edit_the_meta( $value ) {
+		$endpoint = '/wp/v2/' . Taxonomy::SLUG . '/' . $this->term1->term_id;
+
+		$request = new WP_REST_Request(
+			'POST',
+			$endpoint
+		);
+
+		$request->set_header( 'content-type', 'application/json' );
+
+		$request->set_body(
+			wp_json_encode(
+				[
+					'meta' => [
+						Logo::get_key() => $value,
+					],
+				]
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		return $response;
+	}
+
+	/**
+	 * Test editing without permissions
+	 */
+	public function test_unauthorized() {
+		wp_set_current_user( 0 );
+		$response = $this->distpatch_request_to_edit_the_meta( 123 );
+		$this->assertSame( 401, $response->get_status() );
+
+		wp_set_current_user( $this->secondary_user_id->ID );
+		$response = $this->distpatch_request_to_edit_the_meta( 123 );
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * Test setting a valid value
+	 */
+	public function test_valid_input() {
+		wp_set_current_user( $this->user_id->ID );
+		$response = $this->distpatch_request_to_edit_the_meta( 123 );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 123, $data['meta'][ Logo::get_key() ] );
+	}
+
+	/**
+	 * Test setting an invalid value
+	 */
+	public function test_invalid_input() {
+		wp_set_current_user( $this->user_id->ID );
+		$response = $this->distpatch_request_to_edit_the_meta( 'invalid' );
+		$data     = $response->get_data();
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+}


### PR DESCRIPTION
Adds the custom logo option.

Testing on the front end:

* Create 2 brands
* Upload an image to be used as a logo, and get its attachment id
* Add the custom logo to one of the brands: `add_term_meta($term_id, '_logo', $attachment_id)`;
* Visit the home of each brand and see the logo changing
* Create a post and assign it to one (only one) of the brands
* Visit the post and see the correct logo being displayed