### PR TITLE
feat: Add theme colors

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -118,6 +118,7 @@ class Admin {
 			'is_debug_mode'       => class_exists( \Newspack\Newspack::class ) && \Newspack\Newspack::is_debug_mode(),
 			'has_completed_setup' => get_option( NEWSPACK_SETUP_COMPLETE ),
 			'site_title'          => get_option( 'blogname' ),
+			'theme_colors'        => Customizations\Theme_Colors::get_registered_theme_colors(),
 		);
 
 		wp_localize_script( self::MULTI_BRANDED_PAGE_SLUG, 'newspack_urls', $urls );

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -22,6 +22,7 @@ class Initializer {
 		Customizations\Url::init();
 		Customizations\ShowPageOnFront::init();
 		Customizations\Logo::init();
+		Customizations\Theme_Colors::init();
 	}
 
 }

--- a/includes/class-taxonomy.php
+++ b/includes/class-taxonomy.php
@@ -51,7 +51,7 @@ class Taxonomy {
 	 * Runs the initialization.
 	 */
 	public static function init() {
-		add_action( 'init', [ __CLASS__, 'register_taxonomy' ] );
+		add_action( 'setup_theme', [ __CLASS__, 'register_taxonomy' ] );
 		add_action( 'wp', [ __CLASS__, 'determine_current_brand' ] );
 
 		add_action( 'rest_api_init', [ __CLASS__, 'register_options' ] );
@@ -157,6 +157,7 @@ class Taxonomy {
 		Meta\ShowPageOnFront::init();
 		Meta\Post_Primary_Brand::init();
 		Meta\Logo::init();
+		Meta\Theme_Colors::init();
 	}
 
 	/**

--- a/includes/customizations/class-theme-colors.php
+++ b/includes/customizations/class-theme-colors.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Newspack Multi-branded site taxonomy.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Multibranded_Site\Customizations;
+
+use Newspack_Multibranded_Site\Meta\Theme_Colors as Theme_Colors_Meta;
+use Newspack_Multibranded_Site\Taxonomy;
+
+/**
+ * Class to handle the Theme_Colors Customization
+ */
+class Theme_Colors {
+
+	/**
+	 * Initializes
+	 */
+	public static function init() {
+		$colors = self::get_registered_theme_colors();
+		$colors = [
+			[
+				'theme_mod_name' => 'primary_color',
+				'label'          => __( 'Primary Color', 'newspack' ),
+				'default'        => '#00669b',
+			],
+		];
+		foreach ( $colors as $color ) {
+			add_filter( 'theme_mod_' . $color['theme_mod_name'], [ __CLASS__, 'filter_theme_color' ] );
+		}
+	}
+
+	/**
+	 * Gets the theme colors that will be customizable for each brand.
+	 *
+	 * @return array The theme colors. Each item in the array should one "theme_mod" that holds a color code.
+	 */
+	public static function get_registered_theme_colors() {
+		/**
+		 * Filters the theme colors that will be customizable for each brand.
+		 *
+		 * Themes should use the filter to register which colors they want to be customizable.
+		 *
+		 * @param array $theme_colors The theme colors. Each item should be an array with the following keys:
+		 *                           - theme_mod_name: The name of the theme_mod that holds the color code.
+		 *                           - label: The label that will be displayed in the UI.
+		 *                           - default: The default color code.
+		 */
+		return apply_filters( 'newspack_multibranded_site_theme_colors', [] );
+	}
+
+	/**
+	 * Checks if the current request is for a brand that has a custom color
+	 *
+	 * Themes can use this method to determine if their colors are being filtered by this plugin
+	 *
+	 * @param array $color_names An array of color names to check. If empty, it will check if any color is being filtered.
+	 * @return bool
+	 */
+	public static function current_brand_has_custom_colors( $color_names = [] ) {
+		$brand = Taxonomy::get_current();
+		if ( ! $brand ) {
+			return false;
+		}
+		$custom_colors = get_term_meta( $brand->term_id, Theme_Colors_Meta::get_key(), true );
+		if ( ! empty( $custom_colors ) ) {
+			if ( empty( $color_names ) ) {
+				return true;
+			}
+			foreach ( $custom_colors as $custom_color ) {
+				if ( in_array( $custom_color['name'], $color_names, true ) ) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Filters the theme color
+	 *
+	 * @param string $value The theme mod value.
+	 * @return string
+	 */
+	public static function filter_theme_color( $value ) {
+		$brand = Taxonomy::get_current();
+		if ( ! $brand ) {
+			return $value;
+		}
+		$theme_mod_name = str_replace( 'theme_mod_', '', current_filter() );
+		$custom_colors  = get_term_meta( $brand->term_id, Theme_Colors_Meta::get_key(), true );
+
+		if ( ! empty( $custom_colors ) ) {
+			foreach ( $custom_colors as $custom_color ) {
+				if ( $custom_color['name'] === $theme_mod_name ) {
+					return $custom_color['color'];
+				}
+			}
+		}
+
+		return $value;
+	}
+
+}

--- a/includes/customizations/class-theme-colors.php
+++ b/includes/customizations/class-theme-colors.php
@@ -19,14 +19,18 @@ class Theme_Colors {
 	 * Initializes
 	 */
 	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_theme_colors_filters' ] );
+	}
+
+	/**
+	 * Registers the filters that will be used to filter the theme colors
+	 *
+	 * Running on init so themes have time to filter the registered colors
+	 *
+	 * @return void
+	 */
+	public static function register_theme_colors_filters() {
 		$colors = self::get_registered_theme_colors();
-		$colors = [
-			[
-				'theme_mod_name' => 'primary_color',
-				'label'          => __( 'Primary Color', 'newspack' ),
-				'default'        => '#00669b',
-			],
-		];
 		foreach ( $colors as $color ) {
 			add_filter( 'theme_mod_' . $color['theme_mod_name'], [ __CLASS__, 'filter_theme_color' ] );
 		}

--- a/includes/meta/class-theme-colors.php
+++ b/includes/meta/class-theme-colors.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Newspack Multi-branded site taxonomy.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Multibranded_Site\Meta;
+
+use Newspack_Multibranded_Site\Meta;
+
+/**
+ * Class to handle the Theme Colors Meta
+ */
+class Theme_Colors extends Meta {
+
+	/**
+	 * Gets the meta key
+	 *
+	 * @return string
+	 */
+	public static function get_key() {
+		return '_theme_colors';
+	}
+
+	/**
+	 * Gets the meta description
+	 *
+	 * @return string
+	 */
+	public static function get_description() {
+		return __( 'An array of customizable colors defined by the theme. Each item has a name, which refers to the theme_mod name, and a value, which is a color hex code.', 'newspack-multibranded-site' );
+	}
+
+	/**
+	 * Gets the meta schema
+	 *
+	 * @return array
+	 */
+	public static function get_schema() {
+		return array(
+			'type'     => 'array',
+			'items'    => [
+				'type'       => 'object',
+				'properties' => [
+					'name'  => [
+						'type' => 'string',
+					],
+					'color' => [
+						'type'      => 'string',
+						'maxLength' => 7,
+						'pattern'   => '^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$',
+					],
+				],
+			],
+			'nullable' => true,
+			'default'  => [],
+		);
+	}
+
+}

--- a/tests/unit-tests/test-customization-theme-colors.php
+++ b/tests/unit-tests/test-customization-theme-colors.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Class TestThemeColorsCustomization
+ *
+ * @package Newspack_Multibranded_Site
+ */
+
+use Newspack_Multibranded_Site\Taxonomy;
+use Newspack_Multibranded_Site\Meta\Theme_Colors as Theme_Colors_Meta;
+use Newspack_Multibranded_Site\Customizations\Theme_Colors as Theme_Colors_Customization;
+
+/**
+ * Test the Logo filter.
+ */
+class TestThemeColorsCustomization extends WP_UnitTestCase {
+
+	/**
+	 * Add registered colors as the theme does
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+		add_filter(
+			'newspack_multibranded_site_theme_colors',
+			function() {
+				return [
+					[
+						'theme_mod_name' => 'primary_color',
+						'label'          => 'Primary Color',
+						'default'        => '#00669b',
+					],
+				];
+			}
+		);
+	}
+
+	/**
+	 * Tests filter theme colors
+	 */
+	public function test_filter_theme_colors() {
+		$term_without_theme_colors = $this->factory->term->create_and_get( [ 'taxonomy' => Taxonomy::SLUG ] );
+		$term_with_theme_colors    = $this->factory->term->create_and_get( [ 'taxonomy' => Taxonomy::SLUG ] );
+		add_term_meta(
+			$term_with_theme_colors->term_id,
+			Theme_Colors_Meta::get_key(),
+			[
+				[
+					'name'  => 'primary_color',
+					'color' => '#000000',
+				],
+			]
+		);
+
+		Taxonomy::set_primary( $term_without_theme_colors );
+		$this->assertSame( false, get_theme_mod( 'primary_color' ) );
+
+		Taxonomy::set_primary( $term_with_theme_colors );
+		$this->go_to( '/' ); // Resets the current brand.
+		$this->assertSame( '#000000', get_theme_mod( 'primary_color' ) );
+	}
+
+	/**
+	 * Tests has theme colors
+	 */
+	public function test_has_theme_colors() {
+		$term_without_theme_colors = $this->factory->term->create_and_get( [ 'taxonomy' => Taxonomy::SLUG ] );
+		$term_with_theme_colors    = $this->factory->term->create_and_get( [ 'taxonomy' => Taxonomy::SLUG ] );
+		add_term_meta(
+			$term_with_theme_colors->term_id,
+			Theme_Colors_Meta::get_key(),
+			[
+				[
+					'name'  => 'primary_color',
+					'color' => '#000000',
+				],
+			]
+		);
+
+		Taxonomy::set_primary( $term_without_theme_colors );
+		$this->assertFalse( Theme_Colors_Customization::current_brand_has_custom_colors() );
+		$this->assertFalse( Theme_Colors_Customization::current_brand_has_custom_colors( [ 'primary_color' ] ) );
+		$this->assertFalse( Theme_Colors_Customization::current_brand_has_custom_colors( [ 'primary_color', 'secondary_color' ] ) );
+		$this->assertFalse( Theme_Colors_Customization::current_brand_has_custom_colors( [ 'secondary_color' ] ) );
+
+		Taxonomy::set_primary( $term_with_theme_colors );
+		$this->go_to( '/' ); // Resets the current brand.
+		$this->assertTrue( Theme_Colors_Customization::current_brand_has_custom_colors() );
+		$this->assertTrue( Theme_Colors_Customization::current_brand_has_custom_colors( [ 'primary_color' ] ) );
+		$this->assertTrue( Theme_Colors_Customization::current_brand_has_custom_colors( [ 'primary_color', 'secondary_color' ] ) );
+		$this->assertFalse( Theme_Colors_Customization::current_brand_has_custom_colors( [ 'secondary_color' ] ) );
+	}
+}

--- a/tests/unit-tests/test-rest-theme-colors.php
+++ b/tests/unit-tests/test-rest-theme-colors.php
@@ -1,0 +1,82 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+use Newspack_Multibranded_Site\Taxonomy;
+use Newspack_Multibranded_Site\Meta\Theme_Colors;
+
+/**
+ * Tests editing the Theme_Colors metadata from the rest api.
+ */
+class Test_Rest_Theme_Colors extends Newspack_Multibranded_Rest_Testcase {
+
+	/**
+	 * Gets a sample valid input
+	 *
+	 * @return array
+	 */
+	public function get_sample_valid_input() {
+		return [
+			[
+				'name'  => 'color_primary',
+				'color' => '#000000',
+			],
+			[
+				'name'  => 'color_secondary',
+				'color' => '#0000FF',
+			],
+			[
+				'name'  => 'color_secondary',
+				'color' => '#00c',
+			],
+		];
+	}
+
+	/**
+	 * Test editing without permissions
+	 */
+	public function test_unauthorized() {
+		wp_set_current_user( 0 );
+		$response = $this->distpatch_request_to_edit_termmeta( Theme_Colors::get_key(), $this->get_sample_valid_input() );
+		$this->assertSame( 401, $response->get_status() );
+
+		wp_set_current_user( $this->secondary_user_id->ID );
+		$response = $this->distpatch_request_to_edit_termmeta( Theme_Colors::get_key(), $this->get_sample_valid_input() );
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * Test setting a valid value
+	 */
+	public function test_valid_input() {
+		wp_set_current_user( $this->user_id->ID );
+		$response = $this->distpatch_request_to_edit_termmeta( Theme_Colors::get_key(), $this->get_sample_valid_input() );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $this->get_sample_valid_input(), $data['meta'][ Theme_Colors::get_key() ] );
+	}
+
+	/**
+	 * Test setting an invalid value
+	 */
+	public function test_invalid_input() {
+		wp_set_current_user( $this->user_id->ID );
+		$invalid  = [
+			[
+				'name'  => 'color_primary',
+				'color' => '#000000',
+			],
+			[
+				'name'  => 'color_secondary',
+				'color' => '#0000FF',
+			],
+			[
+				'name'  => 'color_secondary',
+				'color' => '#00ZZZZ',
+			],
+		];
+		$response = $this->distpatch_request_to_edit_termmeta( Theme_Colors::get_key(), $invalid );
+		$data     = $response->get_data();
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+}


### PR DESCRIPTION

Add the theme color options

* Checkout newspack-theme on https://github.com/Automattic/newspack-theme/pull/2077
* Create two brands (there is no UI yet, go to the post editor and create from there)
* Use wp shell
* Add a custom color to one of the Brands: `update_term_meta( $term_id, '_theme_colors', [ ['name' => 'primary_color_hex', 'color' => '#ff0000']  ]);`
* (Tip, you can see the brand ids with `get_terms(['taxonomy'=>'brand']);`)
* Now you should be able to navigate and see that primary color is red when you are on that brand (brand archive or post with only that brand)

