### PR TITLE
add campaign filter customization

### DIFF
--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -25,6 +25,7 @@ class Initializer {
 		Customizations\Theme_Colors::init();
 		Customizations\Menus::init();
 		Customizations\Blogname::init();
+		Customizations\PopupsShouldDisplayPrompt::init();
 	}
 
 }

--- a/includes/customizations/class-popups-should-display-prompt.php
+++ b/includes/customizations/class-popups-should-display-prompt.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Newspack Multi-branded site taxonomy.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Multibranded_Site\Customizations;
+
+use Newspack_Multibranded_Site\Taxonomy;
+
+/**
+ * Class to handle the Blog Name Customization
+ */
+class PopupsShouldDisplayPrompt {
+
+	/**
+	 * Initializes
+	 */
+	public static function init() {
+		add_filter( 'newspack_popups_should_display_prompt_additional_checks', [ __CLASS__, 'filter_should_display' ], 10, 2 );
+	}
+
+	/**
+	 * Performs additional checks to determine if a popup should be displayed.
+	 *
+	 * @param bool   $should_display Should popup be shown.
+	 * @param object $popup The popup to assess.
+	 * @return bool Should popup be shown.
+	 */
+	public static function filter_should_display( $should_display, $popup ) {
+		if ( ! is_array( $popup ) || empty( $popup['id'] ) ) {
+			return $should_display;
+		}
+		$popup_terms = get_the_terms( $popup['id'], Taxonomy::SLUG );
+
+		if ( false === $popup_terms ) {
+			return $should_display; // Popup not assigned to any brand. Nothing to check.
+		}
+
+		$brand = Taxonomy::get_current();
+		if ( ! $brand ) {
+			return false; // We are not currently on any brand, but the prompt is assigned to one or more brands, so don't show it.
+		}
+
+		$popup_term_ids = wp_list_pluck( $popup_terms, 'term_id' );
+		return in_array( $brand->term_id, $popup_term_ids, true );
+	}
+
+}

--- a/tests/unit-tests/test-customization-should-display-prompt.php
+++ b/tests/unit-tests/test-customization-should-display-prompt.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Class TestLogoCustomization
+ *
+ * @package Newspack_Multibranded_Site
+ */
+
+use Newspack_Multibranded_Site\Taxonomy;
+use Newspack_Multibranded_Site\Customizations\PopupsShouldDisplayPrompt;
+
+/**
+ * Test the Logo filter.
+ */
+class TestCustomizationShouldDisplayPrompt extends WP_UnitTestCase {
+
+	/**
+	 * Tests an empty popup
+	 */
+	public function test_empty_popup() {
+		$should_display = PopupsShouldDisplayPrompt::filter_should_display( true, [] );
+		$this->assertTrue( $should_display );
+
+		$should_display = PopupsShouldDisplayPrompt::filter_should_display( true, 'invalid' );
+		$this->assertTrue( $should_display );
+	}
+
+	/**
+	 * Test all scenarios
+	 */
+	public function test_no_brand() {
+		$prompt_without_brands  = $this->factory->post->create_and_get();
+		$prompt_with_one_brand  = $this->factory->post->create_and_get();
+		$prompt_with_two_brands = $this->factory->post->create_and_get();
+
+		$brand1 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+		$brand2 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+		$brand3 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+
+		wp_set_post_terms( $prompt_with_one_brand->ID, $brand1->term_id, Taxonomy::SLUG );
+		wp_set_post_terms( $prompt_with_two_brands->ID, [ $brand1->term_id, $brand2->term_id ], Taxonomy::SLUG );
+
+		// No current brand.
+		$this->go_to( '/' );
+		$should_display = PopupsShouldDisplayPrompt::filter_should_display( true, [ 'id' => $prompt_without_brands->ID ] );
+		$this->assertEquals( true, $should_display );
+
+		$should_display = PopupsShouldDisplayPrompt::filter_should_display( true, [ 'id' => $prompt_with_one_brand->ID ] );
+		$this->assertEquals( false, $should_display );
+
+		$should_display = PopupsShouldDisplayPrompt::filter_should_display( true, [ 'id' => $prompt_with_two_brands->ID ] );
+		$this->assertEquals( false, $should_display );
+
+		// Brand 1.
+		$this->go_to( get_term_link( $brand1 ) );
+		$should_display = PopupsShouldDisplayPrompt::filter_should_display( true, [ 'id' => $prompt_without_brands->ID ] );
+		$this->assertEquals( true, $should_display );
+
+		$should_display = PopupsShouldDisplayPrompt::filter_should_display( true, [ 'id' => $prompt_with_one_brand->ID ] );
+		$this->assertEquals( true, $should_display );
+
+		$should_display = PopupsShouldDisplayPrompt::filter_should_display( true, [ 'id' => $prompt_with_two_brands->ID ] );
+		$this->assertEquals( true, $should_display );
+
+		// Brand 2.
+		$this->go_to( get_term_link( $brand2 ) );
+		$should_display = PopupsShouldDisplayPrompt::filter_should_display( true, [ 'id' => $prompt_without_brands->ID ] );
+		$this->assertEquals( true, $should_display );
+
+		$should_display = PopupsShouldDisplayPrompt::filter_should_display( true, [ 'id' => $prompt_with_one_brand->ID ] );
+		$this->assertEquals( false, $should_display );
+
+		$should_display = PopupsShouldDisplayPrompt::filter_should_display( true, [ 'id' => $prompt_with_two_brands->ID ] );
+		$this->assertEquals( true, $should_display );
+
+		// Brand 3.
+		$this->go_to( get_term_link( $brand3 ) );
+		$should_display = PopupsShouldDisplayPrompt::filter_should_display( true, [ 'id' => $prompt_without_brands->ID ] );
+		$this->assertEquals( true, $should_display );
+
+		$should_display = PopupsShouldDisplayPrompt::filter_should_display( true, [ 'id' => $prompt_with_one_brand->ID ] );
+		$this->assertEquals( false, $should_display );
+
+		$should_display = PopupsShouldDisplayPrompt::filter_should_display( true, [ 'id' => $prompt_with_two_brands->ID ] );
+		$this->assertEquals( false, $should_display );
+	}
+}


### PR DESCRIPTION

* Make sure you're running Newspack popups with https://github.com/Automattic/newspack-popups/pull/1095
* Create a prompt and configure it to be displayed in every pageview for Everyone
* Confirm it is displayed in every page, regardless of the current brand
* Assign this prompt to a brand: `wp_set_post_terms( $prompt_id, $brand_id, 'brand');`
* Visit the site again and confirm the prompt is only displayed on pages that load the custom brand you've chosen.