### PR TITLE
feat(customization): add brand identifier in body class

### DIFF
--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -26,6 +26,7 @@ class Initializer {
 		Customizations\Menus::init();
 		Customizations\Blogname::init();
 		Customizations\Popups_Should_Display_Prompt::init();
+		Customizations\Body_Class::init();
 	}
 
 }

--- a/includes/customizations/class-body-class.php
+++ b/includes/customizations/class-body-class.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Newspack Multi-branded site taxonomy.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Multibranded_Site\Customizations;
+
+use Newspack_Multibranded_Site\Taxonomy;
+
+/**
+ * Class to handle the Body tag class Customization
+ */
+class Body_Class {
+
+	/**
+	 * Initializes
+	 */
+	public static function init() {
+		add_filter( 'body_class', [ __CLASS__, 'filter_body_class' ] );
+	}
+
+	/**
+	 * Filters the Blog name
+	 *
+	 * @param string[] $classes Body tag classes list.
+	 * @return string[]
+	 */
+	public static function filter_body_class( $classes ) {
+		$brand = Taxonomy::get_current();
+		if ( ! $brand ) {
+			return $classes;
+		}
+
+		$classes[] = "newspack-brand-{$brand->slug}";
+
+		return $classes;
+	}
+
+}


### PR DESCRIPTION
This PR adds the class `newspack-brand-${brand_slug}` to the body classes list.

To test, add a brand, visit its home, posts, and archive pages, ... and check the body class to see `newspack-brand-${brand_slug}`.