### PR TITLE
feat: manage prompt conflicts

### DIFF
--- a/includes/admin/class-prompt-popups.php
+++ b/includes/admin/class-prompt-popups.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Newspack Prompt Popups.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Multibranded_Site\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Newspack Prompt Popups.
+ */
+class Prompt_Popups {
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ) );
+	}
+
+	/**
+	 * Enqueues the scripts to the Post edit screen.
+	 */
+	public static function enqueue_scripts() {
+		$screen = get_current_screen();
+
+		if ( 'newspack_page_newspack-popups-wizard' !== $screen->base ) {
+			return;
+		}
+
+		$asset = require NEWSPACK_MULTIBRANDED_SITE_PLUGIN_DIR . '/dist/promptBrands.asset.php';
+
+		wp_enqueue_script(
+			'newspack-promp-brands',
+			plugins_url( '../../dist/promptBrands.js', __FILE__ ),
+			$asset['dependencies'],
+			$asset['version'],
+			true
+		);
+	}
+}

--- a/includes/admin/class-prompt-popups.php
+++ b/includes/admin/class-prompt-popups.php
@@ -34,7 +34,7 @@ class Prompt_Popups {
 		$asset = require NEWSPACK_MULTIBRANDED_SITE_PLUGIN_DIR . '/dist/promptBrands.asset.php';
 
 		wp_enqueue_script(
-			'newspack-promp-brands',
+			'newspack-prompt-brands',
 			plugins_url( '../../dist/promptBrands.js', __FILE__ ),
 			$asset['dependencies'],
 			$asset['version'],

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -22,6 +22,7 @@ class Admin {
 		Admin\User_Primary_Brand::init();
 		Admin\Cat_Primary_Brand::init();
 		Admin\Post_Primary_Brand::init();
+		Admin\Prompt_Popups::init();
 	}
 
 	/**

--- a/src/prompt-brands/index.js
+++ b/src/prompt-brands/index.js
@@ -7,6 +7,13 @@ addFilter(
 		// If there are conflicting prompts, see if they are for different brands, in which case there will be no conflict.
 		if ( conflicts.length ) {
 			const promptBrandsIds = prompt.brand.length ? prompt.brand.map( b => b.term_id ) : [];
+
+			if ( 0 === promptBrandsIds.length ) {
+				// If the current prompt is not assigned to any brands, the conflicts will remain because
+				// this prompt will be displayed in all pages, including brand pages.
+				return conflicts;
+			}
+
 			const conflictingBrands = conflicts.filter( conflict => {
 				if ( conflict.brand.length ) {
 					let stillHasConflict = false;
@@ -14,14 +21,12 @@ addFilter(
 						// if the prompt has a brand that is also in the conflicting prompt, they are still conflicting.
 						if ( promptBrandsIds.includes( brand.term_id ) ) {
 							stillHasConflict = true;
-							return;
 						}
 					} );
 					return stillHasConflict;
-				} else {
-					// if both prompts have no brands, they are still conflicting.
-					return ! promptBrandsIds.length;
 				}
+				// if current prompt has a brand and conflicting prompt has no brand, they are still conflicting.
+				return true;
 			} );
 			return conflictingBrands;
 		}

--- a/src/prompt-brands/index.js
+++ b/src/prompt-brands/index.js
@@ -1,0 +1,30 @@
+import { addFilter } from '@wordpress/hooks';
+
+addFilter(
+	'newspack.wizards.campaigns.conflictingPrompts',
+	'newspack/multibranded-site/brand-selector-filter',
+	( conflicts, prompt ) => {
+		// If there are conflicting prompts, see if they are for different brands, in which case there will be no conflict.
+		if ( conflicts.length ) {
+			const promptBrandsIds = prompt.brand.length ? prompt.brand.map( b => b.term_id ) : [];
+			const conflictingBrands = conflicts.filter( conflict => {
+				if ( conflict.brand.length ) {
+					let stillHasConflict = false;
+					conflict.brand.forEach( brand => {
+						// if the prompt has a brand that is also in the conflicting prompt, they are still conflicting.
+						if ( promptBrandsIds.includes( brand.term_id ) ) {
+							stillHasConflict = true;
+							return;
+						}
+					} );
+					return stillHasConflict;
+				} else {
+					// if both prompts have no brands, they are still conflicting.
+					return ! promptBrandsIds.length;
+				}
+			} );
+			return conflictingBrands;
+		}
+		return conflicts;
+	}
+);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,11 +14,12 @@ const path = require( 'path' );
  */
 const admin = path.join( __dirname, 'src/admin' );
 const postPrimaryBrand = path.join( __dirname, 'src/post-primary-brand' );
+const promptBrands = path.join( __dirname, 'src/prompt-brands' );
 
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
 	{
-		entry: { admin, postPrimaryBrand },
+		entry: { admin, postPrimaryBrand, promptBrands },
 		'output-path': path.join( __dirname, 'dist' ),
 	}
 );


### PR DESCRIPTION

* Create 2 brands
* Create to Overlay prompts, in the same segment, one assigned to each of the brands
* Go to the Campaigns admin page and see there's a conflict warning - even though they don't conflict, because each of them is in a different brand

Checkout this branch and https://github.com/Automattic/newspack-plugin/pull/2421 and https://github.com/Automattic/newspack-popups/pull/1100

* Build newspack-plugin and refresh the page
* See the conflicts are gone
* Create another overlay prompt in the same segment, without any categories or any brand
* See that this will conflict with the other two prompts, because prompts that are not assigned to any brands will be displayed in every page
* Edit that prompt and add it to one of the brands
* See that it will only conflict with the brand you assigned it to
* Test different combinations
* Challenge the logic

Note: The conflict message says that in case of conflicts only the most recent prompt will be displayed. In my tests, the opposite happens. The older prompt is displayed. (You can test this by editing the prompts publish dates when they are in conflict and seeing which is displayed in the page)