### PR TITLE
fix: only add post meta to associated post types

### DIFF
--- a/includes/class-meta.php
+++ b/includes/class-meta.php
@@ -45,15 +45,26 @@ abstract class Meta {
 			},
 		];
 
-		if ( 'term' === static::$type ) {
-			$params['object_subtype'] = static::get_taxonomy();
+		if ( 'post' === static::$type ) {
+			$post_types = Taxonomy::get_post_types();
+			foreach ( $post_types as $post_type ) {
+				$params['object_subtype'] = $post_type;
+				register_meta(
+					'post',
+					static::get_key(),
+					$params
+				);
+			}
+		} else {
+			if ( 'term' === static::$type ) {
+				$params['object_subtype'] = static::get_taxonomy();
+			}
+			register_meta(
+				static::$type,
+				static::get_key(),
+				$params
+			);
 		}
-
-		register_meta(
-			static::$type,
-			static::get_key(),
-			$params
-		);
 	}
 
 	/**

--- a/src/post-primary-brand/index.js
+++ b/src/post-primary-brand/index.js
@@ -81,7 +81,7 @@ const NewspackPostPrimaryBrand = ( { slug } ) => {
 							options={ [
 								{
 									label: __( 'None', 'newspack-multibranded-site' ),
-									value: ZERO,
+									value: 0,
 								},
 								...terms.map( term => getTermSelectOptionFromId( term ) ).filter( term => term ),
 							] }

--- a/src/post-primary-brand/index.js
+++ b/src/post-primary-brand/index.js
@@ -20,6 +20,8 @@ const DEFAULT_QUERY = {
 
 const EMPTY_ARRAY = [];
 
+const ZERO = 0;
+
 const ADMIN_URL = newspackPostPrimaryBrandVars.adminURL;
 
 const TAXONOMY_SLUG = newspackPostPrimaryBrandVars.taxonomySlug;
@@ -75,11 +77,11 @@ const NewspackPostPrimaryBrand = ( { slug } ) => {
 					{ terms.length > 1 && (
 						<SelectControl
 							label={ __( 'Primary brand', 'newspack-multibranded-site' ) }
-							value={ primaryBrand || 0 }
+							value={ primaryBrand || ZERO }
 							options={ [
 								{
 									label: __( 'None', 'newspack-multibranded-site' ),
-									value: 0,
+									value: ZERO,
 								},
 								...terms.map( term => getTermSelectOptionFromId( term ) ).filter( term => term ),
 							] }


### PR DESCRIPTION
Changes how the Meta class treats `post` meta types. The multibrand post-related meta should only be registered to post types supported by the plugin.

It also tweaks the primary brand JS to avoid unnecessary rerenders by using a reference of zero instead of a new value.