### PR TITLE
feat: change menu position

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -31,15 +31,28 @@ class Admin {
 	 * @return void
 	 */
 	public static function add_admin_menu() {
-		$page_suffix = add_menu_page(
-			__( 'Multi-branded site', 'newspack-multibranded-site' ),
-			__( 'Multi-branded site', 'newspack-multibranded-site' ),
-			'manage_options',
-			self::MULTI_BRANDED_PAGE_SLUG,
-			array( __CLASS__, 'render_page' )
-		);
+		if ( class_exists( 'Newspack\Newspack' ) ) {
+			$page_suffix = add_submenu_page(
+				'newspack',
+				__( 'Multi-branded site', 'newspack-multibranded-site' ),
+				__( 'Multi-branded site', 'newspack-multibranded-site' ),
+				'manage_options',
+				self::MULTI_BRANDED_PAGE_SLUG,
+				array( __CLASS__, 'render_page' )
+			);
+		} else {
+			$icon        = 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjE4cHgiIGhlaWdodD0iNjE4cHgiIHZpZXdCb3g9IjAgMCA2MTggNjE4IiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAgICAgICAgPHBhdGggZD0iTTMwOSwwIEM0NzkuNjU2NDk1LDAgNjE4LDEzOC4zNDQyOTMgNjE4LDMwOS4wMDE3NTkgQzYxOCw0NzkuNjU5MjI2IDQ3OS42NTY0OTUsNjE4IDMwOSw2MTggQzEzOC4zNDM1MDUsNjE4IDAsNDc5LjY1OTIyNiAwLDMwOS4wMDE3NTkgQzAsMTM4LjM0NDI5MyAxMzguMzQzNTA1LDAgMzA5LDAgWiBNMTc0LDE3MSBMMTc0LDI2Mi42NzEzNTYgTDE3NS4zMDUsMjY0IEwxNzQsMjY0IEwxNzQsNDQ2IEwyNDEsNDQ2IEwyNDEsMzMwLjkxMyBMMzUzLjk5Mjk2Miw0NDYgTDQ0NCw0NDYgTDE3NCwxNzEgWiBNNDQ0LDI5OSBMMzg5LDI5OSBMNDEwLjQ3NzYxLDMyMSBMNDQ0LDMyMSBMNDQ0LDI5OSBaIE00NDQsMjM1IEwzMjcsMjM1IEwzNDguMjQ1OTE5LDI1NyBMNDQ0LDI1NyBMNDQ0LDIzNSBaIE00NDQsMTcxIEwyNjQsMTcxIEwyODUuMjkwNTEyLDE5MyBMNDQ0LDE5MyBMNDQ0LDE3MSBaIiBpZD0iQ29tYmluZWQtU2hhcGUiIGZpbGw9IiMyQTdERTEiPjwvcGF0aD4KICAgIDwvZz4KPC9zdmc+';
+			$page_suffix = add_menu_page(
+				__( 'Multi-branded site', 'newspack-multibranded-site' ),
+				__( 'Multi-branded site', 'newspack-multibranded-site' ),
+				'manage_options',
+				self::MULTI_BRANDED_PAGE_SLUG,
+				array( __CLASS__, 'render_page' ),
+				$icon
+			);
+		}
 
-		add_action( 'load-' . $page_suffix, array( __CLASS__, 'admin_init' ) );
+			add_action( 'load-' . $page_suffix, array( __CLASS__, 'admin_init' ) );
 	}
 
 	/**
@@ -105,7 +118,6 @@ class Admin {
 
 		$urls = array(
 			'dashboard'      => esc_url( admin_url( 'admin.php?page=' . self::MULTI_BRANDED_PAGE_SLUG ) ),
-			'public_path'    => \Newspack\Newspack::plugin_url() . '/dist/',
 			'bloginfo'       => array(
 				'name' => get_bloginfo( 'name' ),
 			),
@@ -129,13 +141,12 @@ class Admin {
 		);
 
 		$aux_data = array(
-			'is_e2e'              => class_exists( \Newspack\Starter_Content::class ) && \Newspack\Starter_Content::is_e2e(),
-			'is_debug_mode'       => class_exists( \Newspack\Newspack::class ) && \Newspack\Newspack::is_debug_mode(),
-			'has_completed_setup' => get_option( NEWSPACK_SETUP_COMPLETE ),
-			'site_title'          => get_option( 'blogname' ),
-			'theme_colors'        => Customizations\Theme_Colors::get_registered_theme_colors(),
-			'menu_locations'      => get_registered_nav_menus(),
-			'menus'               => $menus,
+			'is_e2e'         => class_exists( '\Newspack\Starter_Content' ) && \Newspack\Starter_Content::is_e2e(),
+			'is_debug_mode'  => class_exists( '\Newspack\Newspack' ) && \Newspack\Newspack::is_debug_mode(),
+			'site_title'     => get_option( 'blogname' ),
+			'theme_colors'   => Customizations\Theme_Colors::get_registered_theme_colors(),
+			'menu_locations' => get_registered_nav_menus(),
+			'menus'          => $menus,
 		);
 
 		wp_localize_script( self::MULTI_BRANDED_PAGE_SLUG, 'newspack_urls', $urls );


### PR DESCRIPTION
Removes the dependency on Newspack plugin

If Newspack plugin is active, place the menu under the top Newspack menu. If not, use the Newspack logo as an icon.

Test:
* deactivate Newspack plugin
* Confirm you see the menu with the Newspack Logo
* Confirm the admin works fine
* Activate Newspack
* Confirm the menu is now placed under Newspack top level menu
* Confirm the admin still works