### PR TITLE
feat: filter posts by brand in admin

### DIFF
--- a/includes/admin/class-filter-posts.php
+++ b/includes/admin/class-filter-posts.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Newspack Authors Primary Brand.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Multibranded_Site\Admin;
+
+use Newspack_Multibranded_Site\Taxonomy;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Newspack Authors Primary Brand.
+ */
+class Filter_Posts {
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		\add_action( 'restrict_manage_posts', [ __CLASS__, 'add_brands_dropdown' ] );
+	}
+
+	/**
+	 * Adds a dropdown to filter posts by brand
+	 *
+	 * @param string $post_type The post type of the current list.
+	 * @return void
+	 */
+	public static function add_brands_dropdown( $post_type ) {
+		if ( ! in_array( $post_type, Taxonomy::get_post_types(), true ) ) {
+			return;
+		}
+
+		$taxonomy_object = get_taxonomy( Taxonomy::SLUG );
+		$selected        = isset( $_GET[ Taxonomy::SLUG ] ) ? $_GET[ Taxonomy::SLUG ] : '';
+
+		wp_dropdown_categories(
+			array(
+				'show_option_all' => $taxonomy_object->labels->all_items,
+				'taxonomy'        => Taxonomy::SLUG,
+				'name'            => Taxonomy::SLUG,
+				'orderby'         => 'name',
+				'value_field'     => 'slug',
+				'selected'        => $selected,
+				'hierarchical'    => false,
+			)
+		);
+	}
+
+}

--- a/includes/admin/class-filter-posts.php
+++ b/includes/admin/class-filter-posts.php
@@ -35,7 +35,7 @@ class Filter_Posts {
 		}
 
 		$taxonomy_object = get_taxonomy( Taxonomy::SLUG );
-		$selected        = isset( $_GET[ Taxonomy::SLUG ] ) ? $_GET[ Taxonomy::SLUG ] : '';
+		$selected        = isset( $_GET[ Taxonomy::SLUG ] ) ? sanitize_text_field( wp_unslash( $_GET[ Taxonomy::SLUG ] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		wp_dropdown_categories(
 			array(

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -23,6 +23,7 @@ class Admin {
 		Admin\Cat_Primary_Brand::init();
 		Admin\Post_Primary_Brand::init();
 		Admin\Prompt_Popups::init();
+		Admin\Filter_Posts::init();
 	}
 
 	/**

--- a/includes/customizations/class-show-page-on-front.php
+++ b/includes/customizations/class-show-page-on-front.php
@@ -38,7 +38,7 @@ class Show_Page_On_Front {
 	 * @return void
 	 */
 	public static function pre_get_posts( &$query ) {
-		if ( ! $query->is_main_query() ) {
+		if ( ! $query->is_main_query() || is_admin() ) {
 			return;
 		}
 


### PR DESCRIPTION
Adds a filter by brand to the Posts lists in the admin

* Assign some posts and pages to brands
* Visit the Posts and Pages lists in the admin
* Confirm you see a dropdown to filter by brand
* Confirm the filter works

This also fixes a pre_get_post filter been added incorrectly to queries in admin and making the Pages dropdown to be blank when you edit the brand.