### PR TITLE
feat: use brand in pages set as brand fronts

### DIFF
--- a/includes/admin/class-show-page-on-front.php
+++ b/includes/admin/class-show-page-on-front.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Newspack Multi-branded site taxonomy.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Multibranded_Site\Admin;
+
+use Newspack_Multibranded_Site\Customizations\Show_Page_On_Front as Show_Page_On_Front_Customization;
+use Newspack_Multibranded_Site\Taxonomy;
+use WP_Term;
+
+/**
+ * Class to handle the Show_Page_On_Front Admin tweaks
+ */
+class Show_Page_On_Front {
+
+	/**
+	 * Initializes
+	 */
+	public static function init() {
+		add_filter( 'display_post_states', [ __CLASS__, 'add_display_post_states' ], 10, 2 );
+	}
+
+	/**
+	 * Adds a posts state to the page listing if it is a front page for a brand
+	 *
+	 * @param array   $post_states The page post states.
+	 * @param WP_Post $post The current post object.
+	 * @return array
+	 */
+	public static function add_display_post_states( $post_states, $post ) {
+		if ( 'page' !== $post->post_type ) {
+			return $post_states;
+		}
+
+		$brand = Show_Page_On_Front_Customization::get_brand_page_is_cover_for( $post->ID );
+		if ( ! $brand ) {
+			return $post_states;
+		}
+
+		$brand = get_term( $brand, Taxonomy::SLUG );
+		if ( $brand instanceof WP_Term ) {
+			$post_states['newspack-front-page'] = sprintf(
+				/* translators: %s: Brand name */
+				__( 'Front page for %s', 'newspack-multibranded-site' ),
+				$brand->name
+			);
+		}
+		return $post_states;
+	}
+}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -23,6 +23,7 @@ class Admin {
 		Admin\Cat_Primary_Brand::init();
 		Admin\Post_Primary_Brand::init();
 		Admin\Prompt_Popups::init();
+		Admin\Show_Page_On_Front::init();
 	}
 
 	/**

--- a/includes/class-taxonomy.php
+++ b/includes/class-taxonomy.php
@@ -7,6 +7,7 @@
 
 namespace Newspack_Multibranded_Site;
 
+use Newspack_Multibranded_Site\Customizations\Show_Page_On_Front;
 use WP_Term;
 
 /**
@@ -161,6 +162,16 @@ class Taxonomy {
 			$term = get_term( $post_primary_brand, self::SLUG );
 			if ( $term instanceof WP_Term ) {
 				return $term;
+			}
+		}
+
+		if ( 'page' === $post->post_type ) {
+			$brand = Show_Page_On_Front::get_brand_page_is_cover_for( $post->ID );
+			if ( $brand ) {
+				$term = get_term( $brand, self::SLUG );
+				if ( $term instanceof WP_Term ) {
+					return $term;
+				}
 			}
 		}
 	}

--- a/includes/customizations/class-show-page-on-front.php
+++ b/includes/customizations/class-show-page-on-front.php
@@ -16,6 +16,15 @@ use Newspack_Multibranded_Site\Taxonomy;
 class Show_Page_On_Front {
 
 	/**
+	 * Option used to store all pages that are been used as Front pages
+	 *
+	 * This allows us to easily identify if a given page is the front page of a brand
+	 *
+	 * The option itself is an array where the keys are the page IDs and the values the brand IDs
+	 */
+	const FRONT_PAGES_OPTION_KEY = 'newspack_multibranded_site_front_pages';
+
+	/**
 	 * Whether the query has been filtered in the current request
 	 *
 	 * @var boolean
@@ -29,6 +38,8 @@ class Show_Page_On_Front {
 		add_action( 'pre_get_posts', [ __CLASS__, 'pre_get_posts' ], 20 );
 		add_filter( 'body_class', [ __CLASS__, 'body_class' ], 10, 2 );
 		add_filter( 'template_include', [ __CLASS__, 'template_include' ] );
+		add_action( 'updated_term_meta', [ __CLASS__, 'on_term_meta_update' ], 10, 4 );
+		add_action( 'added_term_meta', [ __CLASS__, 'on_term_meta_update' ], 10, 4 );
 	}
 
 	/**
@@ -112,5 +123,63 @@ class Show_Page_On_Front {
 		return $template;
 	}
 
+	/**
+	 * Gets the front pages option
+	 *
+	 * @return array
+	 */
+	protected static function get_front_pages() {
+		$front_pages = get_option( self::FRONT_PAGES_OPTION_KEY, [] );
+		if ( ! is_array( $front_pages ) ) {
+			$front_pages = [];
+		}
+		return $front_pages;
+	}
+
+	/**
+	 * Updates the front pages option
+	 *
+	 * @param array $front_pages The front pages array. Keys are page IDs and values Brand IDs.
+	 * @return void
+	 */
+	protected static function update_front_pages( $front_pages ) {
+		update_option( self::FRONT_PAGES_OPTION_KEY, $front_pages );
+	}
+
+	/**
+	 * Updates the front pages option when a term meta is updated
+	 *
+	 * @param int    $meta_id The Meta ID.
+	 * @param int    $object_id The Object ID.
+	 * @param string $meta_key The Meta key.
+	 * @param string $meta_value The Meta value.
+	 * @return void
+	 */
+	public static function on_term_meta_update( $meta_id, $object_id, $meta_key, $meta_value ) {
+		if ( '_show_page_on_front' === $meta_key ) {
+			$front_pages     = self::get_front_pages();
+			$pages_by_brands = array_flip( $front_pages );
+			if ( empty( $meta_value ) && isset( $pages_by_brands[ $object_id ] ) ) {
+				unset( $front_pages[ $pages_by_brands[ $object_id ] ] );
+				self::update_front_pages( $front_pages );
+				return;
+			}
+			if ( ! empty( $meta_value ) ) {
+				$front_pages[ (int) $meta_value ] = (int) $object_id;
+				self::update_front_pages( $front_pages );
+			}
+		}
+	}
+
+	/**
+	 * If a page is set as the front page for a brand, returns the brand ID
+	 *
+	 * @param int $page_id The page ID.
+	 * @return ?int The Brand ID. Null if the page is not set as the front page for any brand
+	 */
+	public static function get_brand_page_is_cover_for( $page_id ) {
+		$front_pages = self::get_front_pages();
+		return isset( $front_pages[ $page_id ] ) ? $front_pages[ $page_id ] : null;
+	}
 
 }

--- a/tests/unit-tests/test-customization-page-on-front.php
+++ b/tests/unit-tests/test-customization-page-on-front.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Class TestCustomizationPageOnFront
+ *
+ * @package Newspack_Multibranded_Site
+ */
+
+use Newspack_Multibranded_Site\Taxonomy;
+use Newspack_Multibranded_Site\Meta\Show_Page_On_Front as Show_Page_On_Front_Meta;
+use Newspack_Multibranded_Site\Customizations\Show_Page_On_Front;
+
+/**
+ * Test the Page on Front Customization.
+ */
+class TestCustomizationPageOnFront extends WP_UnitTestCase {
+
+	/**
+	 * Tests the hook that populates the front pages option
+	 */
+	public function test_options_hook() {
+		$brand_with_page_on_front = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+		add_term_meta( $brand_with_page_on_front->term_id, Show_Page_On_Front_Meta::get_key(), 123 );
+		$this->assertSame( $brand_with_page_on_front->term_id, Show_Page_On_Front::get_brand_page_is_cover_for( 123 ) );
+
+		update_term_meta( $brand_with_page_on_front->term_id, Show_Page_On_Front_Meta::get_key(), 0 );
+		$this->assertNull( Show_Page_On_Front::get_brand_page_is_cover_for( 123 ) );
+	}
+
+}

--- a/tests/unit-tests/test-customization-page-on-front.php
+++ b/tests/unit-tests/test-customization-page-on-front.php
@@ -22,8 +22,13 @@ class TestCustomizationPageOnFront extends WP_UnitTestCase {
 		add_term_meta( $brand_with_page_on_front->term_id, Show_Page_On_Front_Meta::get_key(), 123 );
 		$this->assertSame( $brand_with_page_on_front->term_id, Show_Page_On_Front::get_brand_page_is_cover_for( 123 ) );
 
+		add_term_meta( $brand_with_page_on_front->term_id, Show_Page_On_Front_Meta::get_key(), 456 );
+		$this->assertSame( $brand_with_page_on_front->term_id, Show_Page_On_Front::get_brand_page_is_cover_for( 456 ) );
+		$this->assertNull( Show_Page_On_Front::get_brand_page_is_cover_for( 123 ) );
+
 		update_term_meta( $brand_with_page_on_front->term_id, Show_Page_On_Front_Meta::get_key(), 0 );
 		$this->assertNull( Show_Page_On_Front::get_brand_page_is_cover_for( 123 ) );
+		$this->assertNull( Show_Page_On_Front::get_brand_page_is_cover_for( 456 ) );
 	}
 
 }

--- a/tests/unit-tests/test-taxonomy.php
+++ b/tests/unit-tests/test-taxonomy.php
@@ -204,5 +204,9 @@ class TestTaxonomy extends WP_UnitTestCase {
 		// Brand with page on front.
 		$this->go_to( get_term_link( $brand_with_page_on_front ) );
 		$this->assertSame( $brand_with_page_on_front->term_id, Taxonomy::get_current()->term_id, 'Brand should be returned if on brand with page on front' );
+
+		// Page set to be the front page of a brand.
+		$this->go_to( get_permalink( $page2->ID ) );
+		$this->assertSame( $brand_with_page_on_front->term_id, Taxonomy::get_current()->term_id, 'Page that is set to be used as front page of a brand should load that brand' );
 	}
 }


### PR DESCRIPTION
* Filters the permalink for pages that have been set as a front page for a brand
* Display a post state near the page name in the page list
* Use the correct brand layout if you visit the page URL

Testing:

* Set up a brand and choose to display a page on Front
* Make sure the page is NOT assigned the brand in the page editor
* On the page lists, confirm you see a State near the page name saying it is the Front page for that brand

![image](https://github.com/Automattic/newspack-multibranded-site/assets/971483/61444726-1d3a-4ed0-8ff7-c97064169138)

* Confirm that the "View" quick action points to the brand home page, and not the page URL
* Edit the page and confirm that the links to the page also point to the Brand (in the sidebar and in the notice when you save the page)
* Grab the page slug and access the page directly in the browser in its original URL
* Confirm that it loads the brand the page is the cover for