### PR TITLE
fix: update help site URL

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -114,7 +114,7 @@ class Admin {
 			),
 			'homepage'       => get_edit_post_link( get_option( 'page_on_front', false ) ),
 			'site'           => get_site_url(),
-			'support'        => esc_url( 'https://newspack.com/support/' ),
+			'support'        => esc_url( 'https://help.newspack.com/' ),
 			'support_email'  => $support_email,
 		);
 


### PR DESCRIPTION
### Changes in this pull request

Updates a support link that hasn't been updated to the new URL.

### How to test the changes in this Pull Request:

1. Check out this branch, visit the "Multi-branded Site" wizard page in the admin.
2. Confirm that the "Documentation" link at the bottom of the page leads to help.newspack.com, not newspack.com/support.
