### PR TITLE
Improve fallback brand handling with categories

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -169,7 +169,6 @@ install_db() {
 	if [ $(mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]
 	then
 		echo "Reinstalling will delete the existing test database ($DB_NAME)"
-		read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB
 		recreate_db $DELETE_EXISTING_DB
 	else
 		create_db

--- a/includes/class-taxonomy.php
+++ b/includes/class-taxonomy.php
@@ -150,12 +150,14 @@ class Taxonomy {
 			return;
 		}
 
+		// Check if post is assigned to only one brand.
 		$terms = wp_get_post_terms( $post->ID, self::SLUG );
 
 		if ( 1 === count( $terms ) ) {
 			return $terms[0];
 		}
 
+		// Check if post has a primary brand.
 		$post_primary_brand = get_post_meta( $post->ID, self::PRIMARY_META_KEY, true );
 
 		if ( $post_primary_brand ) {
@@ -165,6 +167,7 @@ class Taxonomy {
 			}
 		}
 
+		// Check if post is a cover page for a brand.
 		if ( 'page' === $post->post_type ) {
 			$brand = Show_Page_On_Front::get_brand_page_is_cover_for( $post->ID );
 			if ( $brand ) {
@@ -175,13 +178,23 @@ class Taxonomy {
 			}
 		}
 
-		$categories = wp_get_post_categories( $post->ID );
+		// Check if post is assigned to a brand through a category.
+		$categories     = wp_get_post_categories( $post->ID );
+		$category_brand = null;
 		foreach ( $categories as $category ) {
-			$category_brand = self::get_current_brand_for_term( $category );
-			if ( $category_brand ) {
-				return $category_brand;
+			$brand = self::get_current_brand_for_term( $category );
+			if ( $brand ) {
+				if ( ! $category_brand || $category_brand->term_id === $brand->term_id ) {
+					$category_brand = $brand;
+					continue;
+				}
+
+				// Found more than one eligible brand, return null.
+				return null;
 			}
 		}
+
+		return $category_brand;
 	}
 
 	/**

--- a/includes/class-taxonomy.php
+++ b/includes/class-taxonomy.php
@@ -174,6 +174,14 @@ class Taxonomy {
 				}
 			}
 		}
+
+		$categories = wp_get_post_categories( $post->ID );
+		foreach ( $categories as $category ) {
+			$category_brand = self::get_current_brand_for_term( $category );
+			if ( $category_brand ) {
+				return $category_brand;
+			}
+		}
 	}
 
 	/**

--- a/tests/unit-tests/test-taxonomy.php
+++ b/tests/unit-tests/test-taxonomy.php
@@ -60,10 +60,24 @@ class TestTaxonomy extends WP_UnitTestCase {
 	 * Test fallback logic for posts that are in a branded category but don't have a brand assigned.
 	 */
 	public function test_get_current_brand_for_post_fallback() {
-		$brand = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+		$brand  = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+		$brand2 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
 
 		$category_with_brand = $this->factory->term->create_and_get( array( 'taxonomy' => 'category' ) );
 		add_term_meta( $category_with_brand->term_id, Taxonomy::PRIMARY_META_KEY, $brand->term_id );
+
+		$category_with_brand2 = $this->factory->term->create_and_get( array( 'taxonomy' => 'category' ) );
+		add_term_meta( $category_with_brand2->term_id, Taxonomy::PRIMARY_META_KEY, $brand2->term_id );
+
+		$category_with_brand2_2 = $this->factory->term->create_and_get( array( 'taxonomy' => 'category' ) );
+		add_term_meta( $category_with_brand2_2->term_id, Taxonomy::PRIMARY_META_KEY, $brand2->term_id );
+
+		$category_with_parent_branded = $this->factory->term->create_and_get(
+			array(
+				'taxonomy' => 'category',
+				'parent'   => $brand2->term_id,
+			)
+		);
 
 		$category_without_brand = $this->factory->term->create_and_get( array( 'taxonomy' => 'category' ) );
 
@@ -73,8 +87,24 @@ class TestTaxonomy extends WP_UnitTestCase {
 		$post2 = $this->factory->post->create_and_get( array( 'post_title' => 'Post 2' ) );
 		wp_set_post_categories( $post2->ID, [ $category_without_brand->term_id ] );
 
+		$post_one_branded_one_unbranded = $this->factory->post->create_and_get( array( 'post_title' => 'Post one branded one unbranded' ) );
+		wp_set_post_categories( $post_one_branded_one_unbranded->ID, [ $category_without_brand->term_id, $category_with_brand->term_id ] );
+
+		$post_with_two_branded_cats = $this->factory->post->create_and_get( array( 'post_title' => 'Post 3' ) );
+		wp_set_post_categories( $post_with_two_branded_cats->ID, [ $category_with_brand->term_id, $category_with_brand2->term_id ] );
+
+		$post_with_parent_and_child_branded = $this->factory->post->create_and_get( array( 'post_title' => 'Post with parent and child branded cats' ) );
+		wp_set_post_categories( $post_with_parent_and_child_branded->ID, [ $category_with_brand2->term_id, $category_with_parent_branded->term_id ] );
+
+		$post_with_two_cats_in_the_same_brand = $this->factory->post->create_and_get( array( 'post_title' => 'Post with two cats related to the same brand' ) );
+		wp_set_post_categories( $post_with_two_cats_in_the_same_brand->ID, [ $category_with_brand2->term_id, $category_with_brand2_2->term_id ] );
+
 		$this->assertSame( $brand->term_id, Taxonomy::get_current_brand_for_post( $post->ID )->term_id, 'Related brand should be returned for posts in a branded category that are not explicitly branded' );
 		$this->assertSame( null, Taxonomy::get_current_brand_for_post( $post2->ID ), 'Null should be returned for unbranded posts in an unbranded category' );
+		$this->assertSame( $brand->term_id, Taxonomy::get_current_brand_for_post( $post_one_branded_one_unbranded->ID )->term_id, 'Related brand should be returned for posts in multiple categories but when only one is branded' );
+		$this->assertSame( null, Taxonomy::get_current_brand_for_post( $post_with_two_branded_cats->ID ), 'Null should be returned if post is assigned to more than one branded category' );
+		$this->assertSame( $brand2->term_id, Taxonomy::get_current_brand_for_post( $post_with_parent_and_child_branded->ID )->term_id, 'Brand should be returned if post is assigned to more than one branded category, but if they all are related to the same brand' );
+		$this->assertSame( $brand2->term_id, Taxonomy::get_current_brand_for_post( $post_with_two_cats_in_the_same_brand->ID )->term_id, 'Brand should be returned if post is assigned to more than one branded category, but if they all are related to the same brand' );
 	}
 
 	/**


### PR DESCRIPTION
This PR improves the logic for posts that don't officially have a brand but are in a branded category. I think this will make things simpler for publishers that start to use multi-branded after having a site for a while, so we don't need to migrate historic posts.

What it does is associate posts that don't have a brand but are in a branded category with the brand. For example, if you have an Entertainment category associated with the Lifestyle brand, posts in the Entertainment category will have the Lifestyle brand by default instead of no brand.

To test:
1. Create a category (Entertainment in this example). Associate it with a brand (Green header in this example). Create a post in that category and don't assign it a brand.
2. Before applying this patch, view the post. Observe it's unbranded:

<img width="1401" alt="Screenshot 2023-12-05 at 12 32 56 PM" src="https://github.com/Automattic/newspack-multibranded-site/assets/7317227/ad186781-24dc-41e6-99e3-68e5099d8529">

4. After applying this patch, view the post. Observe it's branded with the category's brand:

<img width="1495" alt="Screenshot 2023-12-05 at 12 33 21 PM" src="https://github.com/Automattic/newspack-multibranded-site/assets/7317227/521f3ae1-3b78-440d-a58f-76885699fd78">
