### PR TITLE
fix: remove hyphenation from "Multi-branded" display text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Newspack Multi-branded Site plugin
+# Newspack Multibranded Site plugin
 
-A plugin to allow your site to host multiple brands
+Brand different content and sections of your site with unique colors and navigation.

--- a/includes/admin/class-cat-primary-brand.php
+++ b/includes/admin/class-cat-primary-brand.php
@@ -52,7 +52,7 @@ class Cat_Primary_Brand {
 					<?php endforeach; ?>
 				</select>
 				<p class="description" id="<?php echo esc_attr( Taxonomy::PRIMARY_META_KEY ); ?>-description">
-					<?php echo esc_html__( 'The primary brand defines what brand will be applied to the term\'s archive. (added by Newspack Multi-branded site)', 'newspack-multibranded-site' ); ?>
+					<?php echo esc_html__( 'The primary brand defines what brand will be applied to the term\'s archive. (added by Newspack Multibranded site)', 'newspack-multibranded-site' ); ?>
 				</p>
 			</td>
 		</tr>

--- a/includes/admin/class-show-page-on-front.php
+++ b/includes/admin/class-show-page-on-front.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site taxonomy.
+ * Newspack Multibranded site taxonomy.
  *
  * @package Newspack
  */

--- a/includes/admin/class-user-primary-brand.php
+++ b/includes/admin/class-user-primary-brand.php
@@ -59,7 +59,7 @@ class User_Primary_Brand {
 		?>
 		<div class="newspack-multibranded-site-options">
 		<?php \wp_nonce_field( 'newspack_multibranded_site', 'newspack_multibranded_site_nonce' ); ?>
-			<h2><?php echo esc_html__( 'Multi-branded site Options', 'newspack-multibranded-site' ); ?></h2>
+			<h2><?php echo esc_html__( 'Multibranded site Options', 'newspack-multibranded-site' ); ?></h2>
 			<?php echo esc_html__( 'The user primary brand defines what brand will be applied to the user\'s archive.', 'newspack-multibranded-site' ); ?>
 			<table class="form-table" role="presentation">
 				<tr class="user-<?php echo esc_attr( Meta::get_key() ); ?>-wrap">

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site plugin administration screen handling.
+ * Newspack Multibranded site plugin administration screen handling.
  *
  * @package Newspack
  */
@@ -36,8 +36,8 @@ class Admin {
 		if ( class_exists( 'Newspack\Newspack' ) ) {
 			$page_suffix = add_submenu_page(
 				'newspack',
-				__( 'Multi-branded site', 'newspack-multibranded-site' ),
-				__( 'Multi-branded site', 'newspack-multibranded-site' ),
+				__( 'Multibranded site', 'newspack-multibranded-site' ),
+				__( 'Multibranded site', 'newspack-multibranded-site' ),
 				'manage_options',
 				self::MULTI_BRANDED_PAGE_SLUG,
 				array( __CLASS__, 'render_page' )
@@ -45,8 +45,8 @@ class Admin {
 		} else {
 			$icon        = 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjE4cHgiIGhlaWdodD0iNjE4cHgiIHZpZXdCb3g9IjAgMCA2MTggNjE4IiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+CiAgICAgICAgPHBhdGggZD0iTTMwOSwwIEM0NzkuNjU2NDk1LDAgNjE4LDEzOC4zNDQyOTMgNjE4LDMwOS4wMDE3NTkgQzYxOCw0NzkuNjU5MjI2IDQ3OS42NTY0OTUsNjE4IDMwOSw2MTggQzEzOC4zNDM1MDUsNjE4IDAsNDc5LjY1OTIyNiAwLDMwOS4wMDE3NTkgQzAsMTM4LjM0NDI5MyAxMzguMzQzNTA1LDAgMzA5LDAgWiBNMTc0LDE3MSBMMTc0LDI2Mi42NzEzNTYgTDE3NS4zMDUsMjY0IEwxNzQsMjY0IEwxNzQsNDQ2IEwyNDEsNDQ2IEwyNDEsMzMwLjkxMyBMMzUzLjk5Mjk2Miw0NDYgTDQ0NCw0NDYgTDE3NCwxNzEgWiBNNDQ0LDI5OSBMMzg5LDI5OSBMNDEwLjQ3NzYxLDMyMSBMNDQ0LDMyMSBMNDQ0LDI5OSBaIE00NDQsMjM1IEwzMjcsMjM1IEwzNDguMjQ1OTE5LDI1NyBMNDQ0LDI1NyBMNDQ0LDIzNSBaIE00NDQsMTcxIEwyNjQsMTcxIEwyODUuMjkwNTEyLDE5MyBMNDQ0LDE5MyBMNDQ0LDE3MSBaIiBpZD0iQ29tYmluZWQtU2hhcGUiIGZpbGw9IiMyQTdERTEiPjwvcGF0aD4KICAgIDwvZz4KPC9zdmc+';
 			$page_suffix = add_menu_page(
-				__( 'Multi-branded site', 'newspack-multibranded-site' ),
-				__( 'Multi-branded site', 'newspack-multibranded-site' ),
+				__( 'Multibranded site', 'newspack-multibranded-site' ),
+				__( 'Multibranded site', 'newspack-multibranded-site' ),
 				'manage_options',
 				self::MULTI_BRANDED_PAGE_SLUG,
 				array( __CLASS__, 'render_page' ),

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site plugin initialization.
+ * Newspack Multibranded site plugin initialization.
  *
  * @package Newspack
  */

--- a/includes/class-meta.php
+++ b/includes/class-meta.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site term meta parent class.
+ * Newspack Multibranded site term meta parent class.
  *
  * @package Newspack
  */
@@ -8,7 +8,7 @@
 namespace Newspack_Multibranded_Site;
 
 /**
- * Newspack Multi-branded site meta parent class
+ * Newspack Multibranded site meta parent class
  */
 abstract class Meta {
 

--- a/includes/class-taxonomy.php
+++ b/includes/class-taxonomy.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site taxonomy.
+ * Newspack Multibranded site taxonomy.
  *
  * @package Newspack
  */

--- a/includes/customizations/class-blogname.php
+++ b/includes/customizations/class-blogname.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site taxonomy.
+ * Newspack Multibranded site taxonomy.
  *
  * @package Newspack
  */

--- a/includes/customizations/class-body-class.php
+++ b/includes/customizations/class-body-class.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site taxonomy.
+ * Newspack Multibranded site taxonomy.
  *
  * @package Newspack
  */

--- a/includes/customizations/class-logo.php
+++ b/includes/customizations/class-logo.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site taxonomy.
+ * Newspack Multibranded site taxonomy.
  *
  * @package Newspack
  */

--- a/includes/customizations/class-menus.php
+++ b/includes/customizations/class-menus.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site taxonomy.
+ * Newspack Multibranded site taxonomy.
  *
  * @package Newspack
  */

--- a/includes/customizations/class-popups-should-display-prompt.php
+++ b/includes/customizations/class-popups-should-display-prompt.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site taxonomy.
+ * Newspack Multibranded site taxonomy.
  *
  * @package Newspack
  */

--- a/includes/customizations/class-show-page-on-front.php
+++ b/includes/customizations/class-show-page-on-front.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site taxonomy.
+ * Newspack Multibranded site taxonomy.
  *
  * @package Newspack
  */

--- a/includes/customizations/class-theme-colors.php
+++ b/includes/customizations/class-theme-colors.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site taxonomy.
+ * Newspack Multibranded site taxonomy.
  *
  * @package Newspack
  */

--- a/includes/customizations/class-url.php
+++ b/includes/customizations/class-url.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site taxonomy.
+ * Newspack Multibranded site taxonomy.
  *
  * @package Newspack
  */

--- a/includes/meta/class-category-primary-brand.php
+++ b/includes/meta/class-category-primary-brand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site taxonomy.
+ * Newspack Multibranded site taxonomy.
  *
  * @package Newspack
  */

--- a/includes/meta/class-logo.php
+++ b/includes/meta/class-logo.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site taxonomy.
+ * Newspack Multibranded site taxonomy.
  *
  * @package Newspack
  */

--- a/includes/meta/class-menus.php
+++ b/includes/meta/class-menus.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site taxonomy.
+ * Newspack Multibranded site taxonomy.
  *
  * @package Newspack
  */

--- a/includes/meta/class-post-primary-brand.php
+++ b/includes/meta/class-post-primary-brand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site taxonomy.
+ * Newspack Multibranded site taxonomy.
  *
  * @package Newspack
  */

--- a/includes/meta/class-show-page-on-front.php
+++ b/includes/meta/class-show-page-on-front.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site taxonomy.
+ * Newspack Multibranded site taxonomy.
  *
  * @package Newspack
  */

--- a/includes/meta/class-tag-primary-brand.php
+++ b/includes/meta/class-tag-primary-brand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site taxonomy.
+ * Newspack Multibranded site taxonomy.
  *
  * @package Newspack
  */

--- a/includes/meta/class-theme-colors.php
+++ b/includes/meta/class-theme-colors.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site taxonomy.
+ * Newspack Multibranded site taxonomy.
  *
  * @package Newspack
  */

--- a/includes/meta/class-url.php
+++ b/includes/meta/class-url.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site taxonomy.
+ * Newspack Multibranded site taxonomy.
  *
  * @package Newspack
  */

--- a/includes/meta/class-user-primary-brand.php
+++ b/includes/meta/class-user-primary-brand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Multi-branded site taxonomy.
+ * Newspack Multibranded site taxonomy.
  *
  * @package Newspack
  */

--- a/newspack-multibranded-site.php
+++ b/newspack-multibranded-site.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Plugin Name: Newspack Multi-branded site
- * Description: A plugin to allow your site to host multiple brands
+ * Plugin Name: Newspack Multibranded site
+ * Description: Brand different content and sections of your site with unique colors and navigation.
  * Version: 1.2.0
  * Author: Automattic
  * Author URI: https://newspack.com/

--- a/newspack-multibranded-site.php
+++ b/newspack-multibranded-site.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: Newspack Multibranded site
+ * Plugin Name: Newspack Multibranded Site
  * Description: Brand different content and sections of your site with unique colors and navigation.
  * Version: 1.2.0
  * Author: Automattic


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates all non-code references from "Multi-branded" to "Multibranded".

Also updates the plugin description from "A plugin to allow your site to host multiple brands" to "Brand different content and sections of your site with unique colors and navigation."

A [documentation update](https://help.newspack.com/federated-sites/multi-branded-site/) will also be required.

### How to test the changes in this Pull Request:

1. Install the plugin.
2. Visit `/wp-admin/plugins.php`
3. Confirm that the plugin title is "Newspack Multi-branded site".
4. Delete the plugin.
5. Switch to this branch
6. Install the plugin.
7. Visit `/wp-admin/plugins.php`
8. Confirm that the plugin title is "Newspack Multibranded Site".
### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->