### PR TITLE
feat: ensure regenerator-runtime is available (for WP 6.6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
 				"newspack-scripts": "^5.3.0",
 				"postcss-scss": "^4.0.6",
 				"prettier": "npm:wp-prettier@^2.2.1-beta-1",
+				"regenerator-runtime": "^0.14.1",
 				"stylelint": "^16.2.1"
 			}
 		},
@@ -1880,6 +1881,11 @@
 			"engines": {
 				"node": ">=6.9.0"
 			}
+		},
+		"node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+			"version": "0.13.11",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
 		},
 		"node_modules/@babel/template": {
 			"version": "7.20.7",
@@ -31095,9 +31101,10 @@
 			}
 		},
 		"node_modules/regenerator-runtime": {
-			"version": "0.13.11",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+			"dev": true
 		},
 		"node_modules/regenerator-transform": {
 			"version": "0.15.1",
@@ -37281,6 +37288,13 @@
 			"integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
 			"requires": {
 				"regenerator-runtime": "^0.13.11"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.13.11",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+					"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+				}
 			}
 		},
 		"@babel/template": {
@@ -59791,9 +59805,10 @@
 			}
 		},
 		"regenerator-runtime": {
-			"version": "0.13.11",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.15.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"newspack-scripts": "^5.3.0",
 		"postcss-scss": "^4.0.6",
 		"prettier": "npm:wp-prettier@^2.2.1-beta-1",
+		"regenerator-runtime": "^0.14.1",
 		"stylelint": "^16.2.1"
 	},
 	"repository": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,14 +12,20 @@ const path = require( 'path' );
 /**
  * Internal variables
  */
-const admin = path.join( __dirname, 'src/admin' );
-const postPrimaryBrand = path.join( __dirname, 'src/post-primary-brand' );
-const promptBrands = path.join( __dirname, 'src/prompt-brands' );
+const entry = {
+	admin: path.join( __dirname, 'src/admin' ),
+	postPrimaryBrand: path.join( __dirname, 'src/post-primary-brand' ),
+	promptBrands: path.join( __dirname, 'src/prompt-brands' ),
+};
+
+Object.keys( entry ).forEach( key => {
+	entry[ key ] = [ 'regenerator-runtime/runtime', entry[ key ] ];
+} );
 
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
 	{
-		entry: { admin, postPrimaryBrand, promptBrands },
+		entry,
 		'output-path': path.join( __dirname, 'dist' ),
 	}
 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

WP 6.6 changes some things and `regenerator-runtime` is not available anymore. This PR adds it to every entry file processed by webpack. 

### How to test the changes in this Pull Request:

No functional changes—all should work as expected.

\* `6.6-beta2` to be exact

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->