### PR TITLE
fix: do not break wp_update_term

### DIFF
--- a/includes/admin/class-cat-primary-brand.php
+++ b/includes/admin/class-cat-primary-brand.php
@@ -65,6 +65,11 @@ class Cat_Primary_Brand {
 	 * @param int $term_id Term ID.
 	 */
 	public static function save_term( $term_id ) {
+		// Only act on the edit term screen.
+		if ( ! isset( $_POST[ Taxonomy::PRIMARY_META_KEY ] ) ) {
+			return;
+		}
+
 		check_admin_referer( 'update-tag_' . $term_id );
 
 		if ( ! empty( $_POST[ Taxonomy::PRIMARY_META_KEY ] ) ) {


### PR DESCRIPTION
Not sure if this is easily reproduceable, because I thought we would have caught it earlier.

But that's how I reproduce it:

Just open the wp shell and run: `wp_update_term( 16, 'category', ['parent' => '' ] );`, where `16` is the ID of a category on your site.

What I'm seeing is the shell exiting with `Error: The link you followed has expired.`

## Testing

Edit a tag or category, add a primary brand and save. Make sure it persists. Edit it again and mark primary category as None, make sure it persists.

Run that command on WP Shell again and confirm there are no errors