### PR TITLE
fix: Preserve RSS feed for brands with page on front

### DIFF
--- a/includes/customizations/class-show-page-on-front.php
+++ b/includes/customizations/class-show-page-on-front.php
@@ -45,13 +45,24 @@ class Show_Page_On_Front {
 	}
 
 	/**
+	 * Checks whether the current request is being filtered by this customization
+	 *
+	 * @return boolean
+	 */
+	public static function is_filtered() {
+		return self::$filtered;
+	}
+
+	/**
 	 * Change the query if we want to display a page on front
 	 *
 	 * @param WP_Query $query The WP_Query object.
 	 * @return void
 	 */
 	public static function pre_get_posts( &$query ) {
-		if ( ! $query->is_main_query() || is_admin() ) {
+		self::$filtered = false;
+
+		if ( ! $query->is_main_query() || is_admin() || is_feed() ) {
 			return;
 		}
 
@@ -118,7 +129,7 @@ class Show_Page_On_Front {
 	 * @return string
 	 */
 	public static function template_include( $template ) {
-		if ( is_page() && self::$filtered ) {
+		if ( is_page() && self::is_filtered() ) {
 			$template = get_front_page_template();
 		}
 

--- a/tests/unit-tests/test-customization-page-on-front.php
+++ b/tests/unit-tests/test-customization-page-on-front.php
@@ -30,4 +30,25 @@ class TestCustomizationPageOnFront extends WP_UnitTestCase {
 		$this->assertNull( Show_Page_On_Front::get_brand_page_is_cover_for( 123 ) );
 		$this->assertNull( Show_Page_On_Front::get_brand_page_is_cover_for( 456 ) );
 	}
+
+	/**
+	 * Ensure that front page filter is not applied when visiting the feed for the brand
+	 */
+	public function test_rss_feed_intact() {
+		$brand_with_page_on_front = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+
+		$page2 = $this->factory->post->create_and_get(
+			array(
+				'post_title' => 'Page 2',
+				'post_type'  => 'page',
+			)
+		);
+		add_term_meta( $brand_with_page_on_front->term_id, Show_Page_On_Front_Meta::get_key(), $page2->ID );
+
+		$this->go_to( get_term_link( $brand_with_page_on_front ) );
+		$this->assertTrue( Show_Page_On_Front::is_filtered() );
+
+		$this->go_to( get_term_link( $brand_with_page_on_front ) . '&feed=rss' );
+		$this->assertFalse( Show_Page_On_Front::is_filtered() );
+	}
 }


### PR DESCRIPTION
== Testing ==

* Create a new brand
* Set the "Display on Front" option as "A page"
* Visit the brand page on `/brand/brand-slug` and confirm it displays the page
* on `trunk`, visit  `/brand/brand-slug/feed` and confirm you are redirected
* checkout this branch and try again
* Confirm the feed now works and brings the correct posts

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208410942671779