### PR TITLE
fix(wp-6.7): use wordpress radio control component

### DIFF
--- a/src/admin/views/brands/Brand.js
+++ b/src/admin/views/brands/Brand.js
@@ -1,6 +1,7 @@
 /* global newspack_aux_data */
 
 import apiFetch from '@wordpress/api-fetch';
+import { RadioControl } from '@wordpress/components';
 import { addQueryArgs, cleanForSlug } from '@wordpress/url';
 import { Fragment, useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -15,7 +16,6 @@ import {
 	ImageUpload,
 	ColorPicker,
 	SelectControl,
-	RadioControl,
 	withWizardScreen,
 	hooks,
 } from 'newspack-components';


### PR DESCRIPTION
The newspack-components radio control used in the multibranded site wizard seems to be conflicting with the styles from WP 6.7's radio control component. As a result, the radio inputs appear warped:
    
![Screenshot 2024-11-01 at 16 36 39](https://github.com/user-attachments/assets/17232849-05c8-466e-b25c-ec39b227c6a6)

This PR addresses this issue by just using the default WP radio control component here instead:

![Screenshot 2024-11-01 at 17 14 30](https://github.com/user-attachments/assets/0e051582-0284-4d88-acda-e4e0c0a232ed)


**Testing Instructions**

Note that right now multibranded site wizard is broken as a result of this change https://github.com/Automattic/newspack-multibranded-site/pull/56. To test this, you will need to revert these changes locally until that PR is either reverted or fixed in some other way.

1. With WP 6.7-RC2 installed, go to the multibranded site wizard
2. Confirm the radio inputs don't appear warped
3. Now install WP 6.6 and verify there are still no issues