### PR TITLE
fix(wp-6.7): update radio control styles

### DIFF
--- a/src/admin/views/brands/style.scss
+++ b/src/admin/views/brands/style.scss
@@ -11,12 +11,12 @@
 	&__base-url-radio-control {
 		margin-bottom: 16px;
 
-		.components-base-control__field > div {
+		.components-radio-control__group-wrapper {
 			justify-content: flex-start;
 			flex-direction: row;
 
 			.components-radio-control__option {
-				margin-right: 32px;
+				margin-right: 24px;
 
 				&:last-child {
 					margin-right: 0;

--- a/src/admin/views/brands/style.scss
+++ b/src/admin/views/brands/style.scss
@@ -11,12 +11,13 @@
 	&__base-url-radio-control {
 		margin-bottom: 16px;
 
+		.components-base-control__field > div,
 		.components-radio-control__group-wrapper {
 			justify-content: flex-start;
 			flex-direction: row;
 
 			.components-radio-control__option {
-				margin-right: 24px;
+				margin-right: 20px;
 
 				&:last-child {
 					margin-right: 0;


### PR DESCRIPTION
Closes 1208604228632024-as-1208605400743645/f

Goes with the following main plugin PR: https://github.com/Automattic/newspack-plugin/pull/3518

This PR updates the styles for our radio control component to avoid conflicts with WP 6.7 radio control updates.

Before:
![Screenshot 2024-11-01 at 16 36 39](https://github.com/user-attachments/assets/f0bb9855-2812-4175-84e6-d2915e6c7dcd)

After:
![Screenshot 2024-11-04 at 14 00 26](https://github.com/user-attachments/assets/3626157c-0e31-4a59-a735-6f89110ad1f2)

Testing instructions:

Be sure to also checkout https://github.com/Automattic/newspack-plugin/pull/3518 before testing.

Point the `newspack-components` package to your local instance of `newspack-components` (`src/components` within the `newspack-plugin` directory)

1. `npm install path/to/newspack/components`
2. Navigate to the `newspack-components` directory
3. Compile and prepublish (`npm run compile && npm run prepublishOnly`)
4. Navigate back to `newspack-multibranded-site` directory and reinstall/build (`npm install && npm run build`)

Test radio control inputs (do this for both WP 6.6 and WP 6.7

5. As admin, visit the multibranded site wizard (Newspack > Multibranded Site)
6. Select any brand and edit
7. Scroll to the Settings section and verify the radio control inputs appear as pictured above

