### PR TITLE
fix: revert "refactor: remove unused code (#56)"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,10 @@ require( '@rushstack/eslint-patch/modern-module-resolution' );
 module.exports = {
 	extends: [ './node_modules/newspack-scripts/config/eslintrc.js' ],
 	ignorePatterns: [ 'dist/', 'node_modules/' ],
+	globals: {
+		newspack_urls: 'readonly',
+		newspack_aux_data: 'readonly',
+	},
 	rules: {
 		'no-nested-ternary': 'off',
 		'react/display-name': 'off',

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -115,6 +115,23 @@ class Admin {
 			true
 		);
 
+		$plugin_data   = get_plugin_data( NEWSPACK_MULTIBRANDED_SITE_PLUGIN_FILE );
+		$support_email = ( defined( 'NEWSPACK_SUPPORT_EMAIL' ) && NEWSPACK_SUPPORT_EMAIL ) ? NEWSPACK_SUPPORT_EMAIL : false;
+
+		$urls = array(
+			'dashboard'      => esc_url( admin_url( 'admin.php?page=' . self::MULTI_BRANDED_PAGE_SLUG ) ),
+			'bloginfo'       => array(
+				'name' => get_bloginfo( 'name' ),
+			),
+			'plugin_version' => array(
+				'label' => $plugin_data['Name'] . ' ' . $plugin_data['Version'],
+			),
+			'homepage'       => get_edit_post_link( get_option( 'page_on_front', false ) ),
+			'site'           => get_site_url(),
+			'support'        => esc_url( 'https://help.newspack.com/' ),
+			'support_email'  => $support_email,
+		);
+
 		$menus = array_map(
 			function( $menu ) {
 				return array(
@@ -126,12 +143,15 @@ class Admin {
 		);
 
 		$aux_data = array(
+			'is_e2e'         => class_exists( '\Newspack\Starter_Content' ) && \Newspack\Starter_Content::is_e2e(),
+			'is_debug_mode'  => class_exists( '\Newspack\Newspack' ) && \Newspack\Newspack::is_debug_mode(),
+			'site_title'     => get_option( 'blogname' ),
 			'theme_colors'   => Customizations\Theme_Colors::get_registered_theme_colors(),
 			'menu_locations' => get_registered_nav_menus(),
 			'menus'          => $menus,
-			'site'           => get_site_url(),
 		);
 
+		wp_localize_script( self::MULTI_BRANDED_PAGE_SLUG, 'newspack_urls', $urls );
 		wp_localize_script( self::MULTI_BRANDED_PAGE_SLUG, 'newspack_aux_data', $aux_data );
 
 		\wp_enqueue_script( self::MULTI_BRANDED_PAGE_SLUG );

--- a/src/admin/views/brands/Brand.js
+++ b/src/admin/views/brands/Brand.js
@@ -1,5 +1,3 @@
-/* global newspack_aux_data */
-
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs, cleanForSlug } from '@wordpress/url';
 import { Fragment, useState, useEffect } from '@wordpress/element';
@@ -114,7 +112,7 @@ const Brand = ( { brands = [], saveBrand, fetchLogoAttachment } ) => {
 		} );
 	};
 
-	const baseUrl = `${ newspack_aux_data.site }/${ 'no' === brand.meta._custom_url ? 'brand/' : '' }`;
+	const baseUrl = `${ newspack_urls.site }/${ 'no' === brand.meta._custom_url ? 'brand/' : '' }`;
 
 	const fetchPublicPages = () => {
 		// Limiting to 100 pages, just in case.


### PR DESCRIPTION
Reverts #56. Looks like that code was used by the main Plugin in Newspack Multibranded Site wizard pages.