### PR TITLE
fix: load text domain on init hook

### DIFF
--- a/newspack-multibranded-site.php
+++ b/newspack-multibranded-site.php
@@ -24,16 +24,21 @@ if ( ! defined( 'NEWSPACK_MULTIBRANDED_SITE_PLUGIN_FILE' ) ) {
 	define( 'NEWSPACK_MULTIBRANDED_SITE_PLUGIN_FILE', __FILE__ );
 }
 
-// Load language files.
-load_plugin_textdomain( 'newspack-plugin', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
-
 require_once __DIR__ . '/vendor/autoload.php';
 
 Newspack_Multibranded_Site\Initializer::init();
 
+// Load language files.
+add_action(
+	'init',
+	function () {
+		load_plugin_textdomain( 'newspack-multibranded-site', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+	}
+);
+
 add_action(
 	'plugins_loaded',
-	function() {
+	function () {
 		if ( class_exists( 'Newspack_Manager\\Updater' ) ) {
 			new Newspack_Manager\Updater(
 				'newspack-multibranded-site/newspack-multibranded-site.php',


### PR DESCRIPTION
Fixes a warning about calling `load_plugin_textdomain` too early. Also fixes the text domain itself for the plugin.

### Testing

There are currently no translation files for this plugin, so just test that you don't see a PHP warning `PHP Notice:  Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>newspack-plugin</code> domain was triggered too early`. If you are seeing it on this branch, make sure your `newspack-plugin` repo has the changes from [this Plugin branch](https://github.com/Automattic/newspack-plugin/pull/3629).