### PR TITLE
fix(posts-listing): don't show empty brand dropdown

### DIFF
--- a/includes/admin/class-filter-posts.php
+++ b/includes/admin/class-filter-posts.php
@@ -34,8 +34,14 @@ class Filter_Posts {
 			return;
 		}
 
+		$num_posts_w_brand = wp_count_terms(
+			[
+				'taxonomy'   => Taxonomy::SLUG,
+				'hide_empty' => true,
+			]
+		);
 		// If we have no brands or no posts with a brand, then don't show the dropdown.
-		if ( ! wp_count_terms( array( 'taxonomy' => Taxonomy::SLUG, 'hide_empty' => true ) ) ) {
+		if ( $num_posts_w_brand < 1 ) {
 			return;
 		}
 

--- a/includes/admin/class-filter-posts.php
+++ b/includes/admin/class-filter-posts.php
@@ -34,14 +34,14 @@ class Filter_Posts {
 			return;
 		}
 
-		$num_posts_w_brand = wp_count_terms(
+		$num_posts_with_brand = wp_count_terms(
 			[
 				'taxonomy'   => Taxonomy::SLUG,
 				'hide_empty' => true,
 			]
 		);
 		// If we have no brands or no posts with a brand, then don't show the dropdown.
-		if ( $num_posts_w_brand < 1 ) {
+		if ( $num_posts_with_brand < 1 ) {
 			return;
 		}
 

--- a/includes/admin/class-filter-posts.php
+++ b/includes/admin/class-filter-posts.php
@@ -34,6 +34,11 @@ class Filter_Posts {
 			return;
 		}
 
+		// If we have no brands or no posts with a brand, then don't show the dropdown.
+		if ( ! wp_count_terms( array( 'taxonomy' => Taxonomy::SLUG, 'hide_empty' => true ) ) ) {
+			return;
+		}
+
 		$taxonomy_object = get_taxonomy( Taxonomy::SLUG );
 		$selected        = isset( $_GET[ Taxonomy::SLUG ] ) ? sanitize_text_field( wp_unslash( $_GET[ Taxonomy::SLUG ] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 


### PR DESCRIPTION
* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
 If no brands were configured or no brands were assigned to any posts, there would be a little stub of a drop-down on `wp-admin/edit.php?post_type=post` 

This adds a return if there are no brands or posts with a brand.

Here is a "before shot":
![CleanShot 2025-03-17 at 15 41 47@2x](https://github.com/user-attachments/assets/6d96513f-6eb8-44b0-ad12-f0108ba3143f)


### How to test the changes in this Pull Request:

To recreate the bug (stay on `trunk` for now):
1. Enable `newspack-multibranded-site` and make sure you have no brands configured. 
2. Go to `wp-admin/edit.php?post_type=post` and see that the stub dropdown is there.

With this diff applied:
1. Go to `wp-admin/edit.php?post_type=post` again and verify that the dropdown stub is gone.
2. Add a brand and add it to a post. Verify that the dropdown now gets shown. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209662290342901