### PR TITLE
fix: add customization class to fix site title url

### DIFF
--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -27,6 +27,7 @@ class Initializer {
 		Customizations\Blogname::init();
 		Customizations\Popups_Should_Display_Prompt::init();
 		Customizations\Body_Class::init();
+		Customizations\Site_Title::init();
 		Integrations\Google_Analytics::init();
 	}
 }

--- a/includes/customizations/class-site-title.php
+++ b/includes/customizations/class-site-title.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Newspack Multibranded site title.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Multibranded_Site\Customizations;
+
+use Newspack_Multibranded_Site\Taxonomy;
+
+/**
+ * Class to handle the Site Title customizations for brands.
+ */
+class Site_Title {
+
+	/**
+	 * Initialization.
+	 */
+	public static function init() {
+		add_filter( 'custom_site_tile_url', [ __CLASS__, 'filter_site_url' ] );
+	}
+
+	/**
+	 * Filters the site url.
+	 *
+	 * @param string $site_url The site url.
+	 * @return string
+	 */
+	public static function filter_site_url( $site_url ) {
+		$brand = Taxonomy::get_current();
+		if ( ! $brand ) {
+			return $site_url;
+		}
+
+		return get_term_link( $brand );
+	}
+}

--- a/includes/customizations/class-site-title.php
+++ b/includes/customizations/class-site-title.php
@@ -18,7 +18,7 @@ class Site_Title {
 	 * Initialization.
 	 */
 	public static function init() {
-		add_filter( 'custom_site_tile_url', [ __CLASS__, 'filter_site_url' ] );
+		add_filter( 'newspack_site_title_url', [ __CLASS__, 'filter_site_url' ] );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes the site title URLs in multi-branded sites by implementing a new customization class that integrates with the theme's site title functionality.

NOTE: Requires https://github.com/Automattic/newspack-theme/pull/2486.

The changes include:
- A new `Site_Title` class to handle site title customizations.
- Uses the existing brand taxonomy system to determine the correct URL.

The implementation ensures that when viewing a brand-specific page, the site title link will point to the brand's root page instead of the main site root, improving navigation and user experience in multibranded configurations.

### How to test the changes in this Pull Request:

Check the instructions from https://github.com/Automattic/newspack-theme/pull/2486.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
