### PR TITLE
feat: implement brand override backend logic

### DIFF
--- a/includes/class-taxonomy.php
+++ b/includes/class-taxonomy.php
@@ -44,6 +44,13 @@ class Taxonomy {
 	const PRIMARY_META_KEY = '_primary_brand';
 
 	/**
+	 * The query string parameter used for brand overrides.
+	 *
+	 * @var string
+	 */
+	const BRAND_QUERY_PARAM = 'brand';
+
+	/**
 	 * The current brand, determined depending on the context on WP initiazliation.
 	 *
 	 * @var ?WP_Term
@@ -136,12 +143,13 @@ class Taxonomy {
 	 * If a post has is of a supported post type and has only one brand, it will return this brand, otherwise it will return null.
 	 *
 	 * @param int|WP_Post $post_or_post_id The Post object or the post id.
+	 * @param ?WP_Term    $brand_override  Optional brand to override with, if it's one of the post's brands.
 	 * @return ?WP_Term The current brand for the post.
 	 */
-	public static function get_current_brand_for_post( $post_or_post_id ) {
+	public static function get_current_brand_for_post( $post_or_post_id, $brand_override = null ) {
 		// Account for Brands with page on front.
 		if ( $post_or_post_id instanceof WP_Term ) {
-			return self::get_current_brand_for_term( $post_or_post_id );
+			return self::get_current_brand_for_term( $post_or_post_id, $brand_override );
 		}
 
 		$post = $post_or_post_id instanceof \WP_Post ? $post_or_post_id : get_post( $post_or_post_id );
@@ -150,21 +158,37 @@ class Taxonomy {
 			return;
 		}
 
-		// Check if post is assigned to only one brand.
+		// Get all brands for the post.
 		$terms = wp_get_post_terms( $post->ID, self::SLUG );
 
+		// If post has only one brand, always respect that brand.
 		if ( 1 === count( $terms ) ) {
 			return $terms[0];
 		}
 
-		// Check if post has a primary brand.
-		$post_primary_brand = get_post_meta( $post->ID, self::PRIMARY_META_KEY, true );
-
-		if ( $post_primary_brand ) {
-			$term = get_term( $post_primary_brand, self::SLUG );
-			if ( $term instanceof WP_Term ) {
-				return $term;
+		// If post has multiple brands, handle brand override and primary brand.
+		if ( count( $terms ) > 1 ) {
+			// If we have a brand override and it's one of the post's brands, use it.
+			if ( $brand_override ) {
+				foreach ( $terms as $term ) {
+					if ( $term->term_id === $brand_override->term_id ) {
+						return $brand_override;
+					}
+				}
 			}
+
+			// Check if post has a primary brand.
+			$post_primary_brand = get_post_meta( $post->ID, self::PRIMARY_META_KEY, true );
+
+			if ( $post_primary_brand ) {
+				$term = get_term( $post_primary_brand, self::SLUG );
+				if ( $term instanceof WP_Term ) {
+					return $term;
+				}
+			}
+
+			// Multiple brands without primary or valid override.
+			return;
 		}
 
 		// Check if post is a cover page for a brand.
@@ -182,7 +206,8 @@ class Taxonomy {
 		$categories     = wp_get_post_categories( $post->ID );
 		$category_brand = null;
 		foreach ( $categories as $category ) {
-			$brand = self::get_current_brand_for_term( $category );
+			// Only pass the override if the post has brands.
+			$brand = self::get_current_brand_for_term( $category, count( $terms ) ? $brand_override : null );
 			if ( $brand ) {
 				if ( ! $category_brand || $category_brand->term_id === $brand->term_id ) {
 					$category_brand = $brand;
@@ -200,60 +225,93 @@ class Taxonomy {
 	/**
 	 * Get the current brand based on a term.
 	 *
-	 * If a term is a brand, it will return this brand
+	 * If a term is a brand, it will return this brand.
 	 *
 	 * @param int|WP_Term $term_or_term_id The Term object or the term id.
-	 * @return ?WP_Term The current brand for the post.
+	 * @param ?WP_Term    $brand_override  Optional brand to override with.
+	 * @return ?WP_Term The current brand for the term.
 	 */
-	public static function get_current_brand_for_term( $term_or_term_id ) {
+	public static function get_current_brand_for_term( $term_or_term_id, $brand_override = null ) {
 		$term = $term_or_term_id instanceof WP_Term ? $term_or_term_id : get_term( $term_or_term_id );
+
 		if ( self::SLUG === $term->taxonomy ) {
 			return $term;
 		}
+
 		if ( in_array( $term->taxonomy, [ 'category', 'post_tag' ], true ) ) {
-			return self::recursive_search_term_primary_brand( $term );
+			return self::recursive_search_term_primary_brand( $term, $brand_override );
 		}
 	}
 
 	/**
 	 * Finds the primary brand for a term, searching recursively through ancestors.
 	 *
-	 * @param WP_Term $term The Term.
+	 * @param WP_Term  $term           The Term.
+	 * @param ?WP_Term $brand_override Optional brand to override with.
 	 * @return ?WP_Term The primary brand for the term.
 	 */
-	protected static function recursive_search_term_primary_brand( WP_Term $term ) {
+	protected static function recursive_search_term_primary_brand( WP_Term $term, $brand_override = null ) {
 		$primary_brand = get_term_meta( $term->term_id, self::PRIMARY_META_KEY, true );
 		if ( $primary_brand ) {
 			$brand = get_term( $primary_brand, self::SLUG );
-			if ( $brand instanceof WP_Term ) {
-				return $brand;
-			}
+			return ( $brand instanceof WP_Term ) ? $brand : null;
 		}
+
 		if ( $term->parent ) {
 			$parent = get_term( $term->parent, $term->taxonomy );
 			if ( $parent instanceof WP_Term ) {
-				return self::recursive_search_term_primary_brand( $parent );
+				$result = self::recursive_search_term_primary_brand( $parent, $brand_override );
+				if ( $result ) {
+					return $result;
+				}
 			}
 		}
+
+		return $brand_override;
 	}
 
 	/**
 	 * Get the current brand based on an author.
 	 *
-	 * If the author has a custom primary brand, it will return this brand
+	 * If the author has a primary brand, it will return this brand.
 	 *
-	 * @param int $author_id The author ID.
-	 * @return ?WP_Term The current brand for the post.
+	 * @param int      $author_id      The author ID.
+	 * @param ?WP_Term $brand_override Optional brand to override with.
+	 * @return ?WP_Term The current brand for the author.
 	 */
-	public static function get_current_brand_for_author( $author_id ) {
+	public static function get_current_brand_for_author( $author_id, $brand_override = null ) {
 		$author_brand = get_user_meta( $author_id, self::PRIMARY_META_KEY, true );
-		if ( ! $author_brand ) {
-			return;
+
+		if ( $author_brand ) {
+			$brand = get_term( $author_brand, self::SLUG );
+			return ( $brand instanceof WP_Term ) ? $brand : null;
 		}
-		$brand = get_term( $author_brand, self::SLUG );
-		if ( $brand instanceof WP_Term ) {
-			return $brand;
+
+		return $brand_override;
+	}
+
+	/**
+	 * Get brand override from URL query parameter if present and valid.
+	 *
+	 * @return \WP_Term|null The brand term if a valid brand override is found in the URL, null otherwise.
+	 */
+	private static function get_brand_override() {
+		if ( ! isset( $_GET[ self::BRAND_QUERY_PARAM ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return null;
 		}
+
+		$brand_slug = sanitize_text_field( wp_unslash( $_GET[ self::BRAND_QUERY_PARAM ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$term       = get_term_by( 'slug', $brand_slug, self::SLUG );
+
+		/**
+		 * Filters the brand override term retrieved from the URL query parameter.
+		 *
+		 * Allows custom logic to modify or replace the brand override term before it's used
+		 * in brand resolution logic. Return null to disable the override.
+		 *
+		 * @param ?\WP_Term $brand_override The brand term retrieved by slug from the URL, or null if not valid.
+		 */
+		return apply_filters( 'newspack_brand_override', $term instanceof \WP_Term ? $term : null );
 	}
 
 	/**
@@ -263,12 +321,15 @@ class Taxonomy {
 	 */
 	public static function determine_current_brand() {
 		global $wp_query;
+
+		$brand_override = self::get_brand_override();
+
 		if ( $wp_query->is_singular() ) {
-			self::$current_brand = self::get_current_brand_for_post( get_queried_object() );
+			self::$current_brand = self::get_current_brand_for_post( get_queried_object(), $brand_override );
 		} elseif ( $wp_query->is_tax() || $wp_query->is_category() || $wp_query->is_tag() ) {
-			self::$current_brand = self::get_current_brand_for_term( get_queried_object() );
+			self::$current_brand = self::get_current_brand_for_term( get_queried_object(), $brand_override );
 		} elseif ( $wp_query->is_author() ) {
-			self::$current_brand = self::get_current_brand_for_author( get_queried_object_id() );
+			self::$current_brand = self::get_current_brand_for_author( get_queried_object_id(), $brand_override );
 		} else {
 			self::$current_brand = null;
 		}

--- a/includes/class-taxonomy.php
+++ b/includes/class-taxonomy.php
@@ -320,18 +320,20 @@ class Taxonomy {
 	 * @return void
 	 */
 	public static function determine_current_brand() {
-		global $wp_query;
+		self::$current_brand = null;
+
+		if ( is_front_page() ) {
+			return;
+		}
 
 		$brand_override = self::get_brand_override();
 
-		if ( $wp_query->is_singular() ) {
+		if ( is_singular() ) {
 			self::$current_brand = self::get_current_brand_for_post( get_queried_object(), $brand_override );
-		} elseif ( $wp_query->is_tax() || $wp_query->is_category() || $wp_query->is_tag() ) {
+		} elseif ( is_tax() || is_category() || is_tag() ) {
 			self::$current_brand = self::get_current_brand_for_term( get_queried_object(), $brand_override );
-		} elseif ( $wp_query->is_author() ) {
+		} elseif ( is_author() ) {
 			self::$current_brand = self::get_current_brand_for_author( get_queried_object_id(), $brand_override );
-		} else {
-			self::$current_brand = null;
 		}
 	}
 }

--- a/tests/unit-tests/test-taxonomy.php
+++ b/tests/unit-tests/test-taxonomy.php
@@ -260,4 +260,336 @@ class TestTaxonomy extends WP_UnitTestCase {
 		$this->go_to( get_permalink( $page2->ID ) );
 		$this->assertSame( $brand_with_page_on_front->term_id, Taxonomy::get_current()->term_id, 'Page that is set to be used as front page of a brand should load that brand' );
 	}
+
+	/**
+	 * Test brand override behavior on posts with multiple brands.
+	 */
+	public function test_brand_override_on_post_with_multiple_brands() {
+		$brand1 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+		$brand2 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+
+		// Create test post with multiple brands.
+		$post = $this->factory->post->create_and_get( array( 'post_title' => 'Post with multiple brands' ) );
+		wp_set_post_terms( $post->ID, array( $brand1->term_id, $brand2->term_id ), Taxonomy::SLUG );
+		add_post_meta( $post->ID, Taxonomy::PRIMARY_META_KEY, $brand2->term_id );
+
+		// Test without brand override.
+		$this->go_to( get_permalink( $post->ID ) );
+		$this->assertSame( $brand2->term_id, Taxonomy::get_current()->term_id, 'Post with multiple brands should use primary brand when no override' );
+
+		// Test with brand override to brand1.
+		$_GET[ Taxonomy::BRAND_QUERY_PARAM ] = $brand1->slug;
+		Taxonomy::determine_current_brand();
+		$this->assertSame( $brand1->term_id, Taxonomy::get_current()->term_id, 'Post with multiple brands should use override brand when it is one of its brands' );
+		unset( $_GET[ Taxonomy::BRAND_QUERY_PARAM ] );
+
+		// Test with invalid brand override.
+		$_GET[ Taxonomy::BRAND_QUERY_PARAM ] = 'non-existent-brand';
+		Taxonomy::determine_current_brand();
+		$this->assertSame( $brand2->term_id, Taxonomy::get_current()->term_id, 'Post should use primary brand when override brand is invalid' );
+		unset( $_GET[ Taxonomy::BRAND_QUERY_PARAM ] );
+	}
+
+	/**
+	 * Test brand override behavior on posts with a single brand.
+	 */
+	public function test_brand_override_on_post_with_single_brand() {
+		$brand1 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+		$brand2 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+
+		// Create test post with single brand.
+		$post = $this->factory->post->create_and_get( array( 'post_title' => 'Post with single brand' ) );
+		wp_set_post_terms( $post->ID, array( $brand2->term_id ), Taxonomy::SLUG );
+
+		// Test without brand override.
+		$this->go_to( get_permalink( $post->ID ) );
+		$this->assertSame( $brand2->term_id, Taxonomy::get_current()->term_id, 'Post with single brand should always use that brand when no override' );
+
+		// Test with brand override to brand1.
+		$_GET[ Taxonomy::BRAND_QUERY_PARAM ] = $brand1->slug;
+		Taxonomy::determine_current_brand();
+		$this->assertSame( $brand2->term_id, Taxonomy::get_current()->term_id, 'Post with single brand should ignore override brand' );
+		unset( $_GET[ Taxonomy::BRAND_QUERY_PARAM ] );
+	}
+
+	/**
+	 * Test brand override behavior on posts with no brand.
+	 */
+	public function test_brand_override_on_post_with_no_brand() {
+		// Create test brand.
+		$brand1 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+
+		// Create test post with no brand.
+		$post = $this->factory->post->create_and_get( array( 'post_title' => 'Post with no brand' ) );
+
+		// Test without brand override.
+		$this->go_to( get_permalink( $post->ID ) );
+		$this->assertSame( null, Taxonomy::get_current(), 'Post with no brand should be neutral when no override' );
+
+		// Test with brand override.
+		$_GET[ Taxonomy::BRAND_QUERY_PARAM ] = $brand1->slug;
+		Taxonomy::determine_current_brand();
+		$this->assertSame( null, Taxonomy::get_current(), 'Post with no brand should ignore override brand' );
+		unset( $_GET[ Taxonomy::BRAND_QUERY_PARAM ] );
+	}
+
+	/**
+	 * Author with a primary and valid brand: should always use the primary brand, ignoring override.
+	 */
+	public function test_brand_override_on_author_archive_with_valid_primary_brand() {
+		$brand1 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+		$brand2 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+		$author = $this->factory->user->create_and_get();
+		add_user_meta( $author->ID, Taxonomy::PRIMARY_META_KEY, $brand1->term_id );
+		$this->go_to( get_author_posts_url( $author->ID ) );
+		$this->assertSame( $brand1->term_id, Taxonomy::get_current()->term_id, 'Author archive should use author brand when no override' );
+		$_GET[ Taxonomy::BRAND_QUERY_PARAM ] = $brand2->slug;
+		Taxonomy::determine_current_brand();
+		$this->assertSame( $brand1->term_id, Taxonomy::get_current()->term_id, 'Author archive should ignore override brand if primary is set' );
+		unset( $_GET[ Taxonomy::BRAND_QUERY_PARAM ] );
+	}
+
+	/**
+	 * Author with a primary but invalid brand: should be neutral.
+	 */
+	public function test_brand_override_on_author_archive_with_invalid_primary_brand() {
+		$author_invalid = $this->factory->user->create_and_get();
+		add_user_meta( $author_invalid->ID, Taxonomy::PRIMARY_META_KEY, 999999 ); // invalid term ID.
+		$this->go_to( get_author_posts_url( $author_invalid->ID ) );
+		$this->assertSame( null, Taxonomy::get_current(), 'Author archive should be neutral if primary brand is invalid' );
+	}
+
+	/**
+	 * Author without a brand but a brand override was passed: should use the override brand.
+	 */
+	public function test_brand_override_on_author_archive_without_brand_with_valid_override() {
+		$brand = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+		$author_no_brand = $this->factory->user->create_and_get();
+		$this->go_to( get_author_posts_url( $author_no_brand->ID ) );
+		$_GET[ Taxonomy::BRAND_QUERY_PARAM ] = $brand->slug;
+		Taxonomy::determine_current_brand();
+		$this->assertSame( $brand->term_id, Taxonomy::get_current()->term_id, 'Author archive should use override brand if no primary brand' );
+		unset( $_GET[ Taxonomy::BRAND_QUERY_PARAM ] );
+	}
+
+	/**
+	 * Author without a brand and a null/invalid brand override passed: should be neutral.
+	 */
+	public function test_brand_override_on_author_archive_without_brand_with_invalid_override() {
+		$author_no_brand = $this->factory->user->create_and_get();
+		$this->go_to( get_author_posts_url( $author_no_brand->ID ) );
+		$_GET[ Taxonomy::BRAND_QUERY_PARAM ] = 'non-existent-brand';
+		Taxonomy::determine_current_brand();
+		$this->assertSame( null, Taxonomy::get_current(), 'Author archive should be neutral if no primary brand and override is invalid' );
+		unset( $_GET[ Taxonomy::BRAND_QUERY_PARAM ] );
+	}
+
+	/**
+	 * Test brand override behavior on terms (categories and tags) with no primary brand but valid override.
+	 */
+	public function test_brand_override_on_term_archive_with_no_primary_with_valid_override() {
+		$brand = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+
+		// Test with category.
+		$category = $this->factory->term->create_and_get( array( 'taxonomy' => 'category' ) );
+		$this->go_to( get_term_link( $category ) );
+		$_GET[ Taxonomy::BRAND_QUERY_PARAM ] = $brand->slug;
+		Taxonomy::determine_current_brand();
+		$this->assertSame( $brand->term_id, Taxonomy::get_current()->term_id, 'Category with no primary should use override brand' );
+		unset( $_GET[ Taxonomy::BRAND_QUERY_PARAM ] );
+
+		// Test with tag.
+		$tag = $this->factory->term->create_and_get( array( 'taxonomy' => 'post_tag' ) );
+		$this->go_to( get_term_link( $tag ) );
+		$_GET[ Taxonomy::BRAND_QUERY_PARAM ] = $brand->slug;
+		Taxonomy::determine_current_brand();
+		$this->assertSame( $brand->term_id, Taxonomy::get_current()->term_id, 'Tag with no primary should use override brand' );
+		unset( $_GET[ Taxonomy::BRAND_QUERY_PARAM ] );
+	}
+
+	/**
+	 * Test brand override behavior on terms (categories and tags) with no primary brand and no override.
+	 */
+	public function test_brand_override_on_term_archive_with_no_primary_no_override() {
+		// Test with category.
+		$category = $this->factory->term->create_and_get( array( 'taxonomy' => 'category' ) );
+		$this->go_to( get_term_link( $category ) );
+		Taxonomy::determine_current_brand();
+		$this->assertSame( null, Taxonomy::get_current(), 'Category with no primary and no override should be neutral' );
+
+		// Test with tag.
+		$tag = $this->factory->term->create_and_get( array( 'taxonomy' => 'post_tag' ) );
+		$this->go_to( get_term_link( $tag ) );
+		Taxonomy::determine_current_brand();
+		$this->assertSame( null, Taxonomy::get_current(), 'Tag with no primary and no override should be neutral' );
+	}
+
+	/**
+	 * Test brand override behavior on terms (categories and tags) with parent that has primary brand.
+	 */
+	public function test_brand_override_on_term_archive_with_parent_with_primary() {
+		$brand = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+
+		// Test with category.
+		$parent_category = $this->factory->term->create_and_get( array( 'taxonomy' => 'category' ) );
+		add_term_meta( $parent_category->term_id, Taxonomy::PRIMARY_META_KEY, $brand->term_id );
+		$child_category = $this->factory->term->create_and_get(
+			array(
+				'taxonomy' => 'category',
+				'parent'   => $parent_category->term_id,
+			)
+		);
+		$this->go_to( get_term_link( $child_category ) );
+		Taxonomy::determine_current_brand();
+		$this->assertSame( $brand->term_id, Taxonomy::get_current()->term_id, 'Child category should use parent\'s primary brand' );
+
+		// Test with tag.
+		$parent_tag = $this->factory->term->create_and_get( array( 'taxonomy' => 'post_tag' ) );
+		add_term_meta( $parent_tag->term_id, Taxonomy::PRIMARY_META_KEY, $brand->term_id );
+		$child_tag = $this->factory->term->create_and_get(
+			array(
+				'taxonomy' => 'post_tag',
+				'parent'   => $parent_tag->term_id,
+			)
+		);
+		$this->go_to( get_term_link( $child_tag ) );
+		Taxonomy::determine_current_brand();
+		$this->assertSame( $brand->term_id, Taxonomy::get_current()->term_id, 'Child tag should use parent\'s primary brand' );
+	}
+
+	/**
+	 * Test brand override behavior on terms (categories and tags) with parent that has no primary brand but valid override.
+	 */
+	public function test_brand_override_on_term_archive_with_parent_no_primary_with_valid_override() {
+		$brand = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+
+		// Test with category.
+		$parent_category = $this->factory->term->create_and_get( array( 'taxonomy' => 'category' ) );
+		$child_category = $this->factory->term->create_and_get(
+			array(
+				'taxonomy' => 'category',
+				'parent'   => $parent_category->term_id,
+			)
+		);
+		$this->go_to( get_term_link( $child_category ) );
+		$_GET[ Taxonomy::BRAND_QUERY_PARAM ] = $brand->slug;
+		Taxonomy::determine_current_brand();
+		$this->assertSame( $brand->term_id, Taxonomy::get_current()->term_id, 'Child category with no primary and parent with no primary should use override brand' );
+		unset( $_GET[ Taxonomy::BRAND_QUERY_PARAM ] );
+
+		// Test with tag.
+		$parent_tag = $this->factory->term->create_and_get( array( 'taxonomy' => 'post_tag' ) );
+		$child_tag = $this->factory->term->create_and_get(
+			array(
+				'taxonomy' => 'post_tag',
+				'parent'   => $parent_tag->term_id,
+			)
+		);
+		$this->go_to( get_term_link( $child_tag ) );
+		$_GET[ Taxonomy::BRAND_QUERY_PARAM ] = $brand->slug;
+		Taxonomy::determine_current_brand();
+		$this->assertSame( $brand->term_id, Taxonomy::get_current()->term_id, 'Child tag with no primary and parent with no primary should use override brand' );
+		unset( $_GET[ Taxonomy::BRAND_QUERY_PARAM ] );
+	}
+
+	/**
+	 * Test brand override behavior on brand archives.
+	 */
+	public function test_brand_override_on_brand_archive() {
+		$brand1 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+		$brand2 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+
+		// Test without brand override.
+		$this->go_to( get_term_link( $brand1 ) );
+		$this->assertSame( $brand1->term_id, Taxonomy::get_current()->term_id, 'Brand archive should use its own brand when no override' );
+
+		// Test with brand override.
+		$_GET[ Taxonomy::BRAND_QUERY_PARAM ] = $brand2->slug;
+		Taxonomy::determine_current_brand();
+		$this->assertSame( $brand1->term_id, Taxonomy::get_current()->term_id, 'Brand archive should ignore override brand' );
+		unset( $_GET[ Taxonomy::BRAND_QUERY_PARAM ] );
+	}
+
+	/**
+	 * Test brand override behavior on home page.
+	 */
+	public function test_brand_override_on_homepage() {
+		$brand1 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+
+		// Test without brand override.
+		$this->go_to( '/' );
+		$this->assertSame( null, Taxonomy::get_current(), 'Home page should be neutral when no override' );
+
+		// Test with brand override.
+		$_GET[ Taxonomy::BRAND_QUERY_PARAM ] = $brand1->slug;
+		Taxonomy::determine_current_brand();
+		$this->assertSame( null, Taxonomy::get_current(), 'Home page should ignore override brand' );
+		unset( $_GET[ Taxonomy::BRAND_QUERY_PARAM ] );
+	}
+
+	/**
+	 * Test that the newspack_brand_override filter allows overriding with a different brand.
+	 */
+	public function test_brand_override_filter_allows_brand_override() {
+		$brand1 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+		$brand2 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+
+		// Create a test post with both brands.
+		$post = $this->factory->post->create_and_get( array( 'post_title' => 'Post for filter test' ) );
+		wp_set_post_terms( $post->ID, array( $brand1->term_id, $brand2->term_id ), Taxonomy::SLUG );
+		add_post_meta( $post->ID, Taxonomy::PRIMARY_META_KEY, $brand1->term_id );
+
+		// Test without filter - should use brand1 from URL.
+		$this->go_to( get_permalink( $post->ID ) );
+		$_GET[ Taxonomy::BRAND_QUERY_PARAM ] = $brand1->slug;
+		Taxonomy::determine_current_brand();
+		$this->assertSame( $brand1->term_id, Taxonomy::get_current()->term_id, 'Should use brand from URL when no filter is applied' );
+		unset( $_GET[ Taxonomy::BRAND_QUERY_PARAM ] );
+
+		// Add filter to override with brand2.
+		$filter_callback = function( $brand ) use ( $brand2 ) {
+			return $brand2;
+		};
+		add_filter( 'newspack_brand_override', $filter_callback );
+
+		// Test with filter - should use brand2 despite URL having brand1.
+		$this->go_to( get_permalink( $post->ID ) );
+		$_GET[ Taxonomy::BRAND_QUERY_PARAM ] = $brand1->slug;
+		Taxonomy::determine_current_brand();
+		$this->assertSame( $brand2->term_id, Taxonomy::get_current()->term_id, 'Should use brand from filter when filter is applied' );
+		unset( $_GET[ Taxonomy::BRAND_QUERY_PARAM ] );
+
+		// Clean up filter.
+		remove_filter( 'newspack_brand_override', $filter_callback );
+		remove_all_filters( 'newspack_brand_override' );
+	}
+
+	/**
+	 * Test that the newspack_brand_override filter can disable override by returning null.
+	 */
+	public function test_brand_override_filter_allows_null_override() {
+		$brand1 = $this->factory->term->create_and_get( array( 'taxonomy' => Taxonomy::SLUG ) );
+
+		// Create a test post with brand1.
+		$post = $this->factory->post->create_and_get( array( 'post_title' => 'Post for null filter test' ) );
+		wp_set_post_terms( $post->ID, array( $brand1->term_id ), Taxonomy::SLUG );
+		add_post_meta( $post->ID, Taxonomy::PRIMARY_META_KEY, $brand1->term_id );
+
+		// Add filter to return null.
+		$null_filter_callback = function() {
+			return null;
+		};
+		add_filter( 'newspack_brand_override', $null_filter_callback );
+
+		// Test with filter returning null - should use post's primary brand since override is disabled.
+		$this->go_to( get_permalink( $post->ID ) );
+		$_GET[ Taxonomy::BRAND_QUERY_PARAM ] = $brand1->slug;
+		Taxonomy::determine_current_brand();
+		$this->assertSame( $brand1->term_id, Taxonomy::get_current()->term_id, 'Should use post brand when filter returns null' );
+		unset( $_GET[ Taxonomy::BRAND_QUERY_PARAM ] );
+
+		// Clean up filter.
+		remove_filter( 'newspack_brand_override', $null_filter_callback );
+		remove_all_filters( 'newspack_brand_override' );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Add support for overriding the current brand via URL parameter (`?brand=brand-slug`) and filters.

- Add brand override check to the taxonomy class.
- Update brand resolution methods to accept optional brand override parameter.
- Add `newspack_brand_override` filter for custom override logic.
- Add extensive test coverage for brand override behavior across posts, author archives, term archives, brand archives, homepage and filter functionality.

### Rules:
The brand override system follows these rules:

1. Posts:
  - If a post has a single brand, that brand is always used and overrides are ignored.
  - If a post has multiple brands:
    - If a valid override (via URL or filter) matches one of the post brands, it is used.
    - If no valid override is present but a primary brand is set, the primary brand is used.
    - If neither a valid override nor a primary brand is present, the post is neutral (no brand).
2. Author archives:
  - If the author has a valid primary brand, that brand is always used and overrides are ignored.
  - If the author has no primary brand, a valid override is used if present.
  - If neither a primary brand nor a valid override is present, the page is neutral.
3. Term archives (categories/tags):
  - If the term or any ancestor has a primary brand, that brand is used and overrides are ignored.
  - If no primary brand is found in the term or ancestors, a valid override is used if present.
  - If neither a primary brand nor a valid override is present, the page is neutral.
4. Brand archives ignore overrides.
5. Homepage ignores overrides.

### How to test the changes in this Pull Request:
- Posts (Single Brand)
  - Create a post (or edit an existing one) and assign it a single brand (e.g. `brand‑a`).
  - Visit the post's permalink (e.g. `/my‑post`) and verify that the post's brand (`brand‑a`) is used.
  - Then, append `?brand=brand‑b` (or any other brand slug) to the URL and reload.
  - Verify that the post's brand (`brand‑a`) is still used (i.e. the override is ignored).

- Posts (Multiple Brands)
  - Create (or edit) a post and assign it multiple brands (e.g. `brand‑a` and `brand‑b`). Optionally, set a primary brand.
  - Visit the post's permalink (e.g. `/my‑multi‑brand‑post`) and verify that (if a primary brand is set) that brand is used.
  - Append `?brand=brand‑a` (or `?brand=brand‑b`) and reload.
  - Verify that the override is used (if it's one of the post's brands).
  - Append `?brand=non‑existent‑brand` and reload. Verify that if a primary brand is set the primary brand is used. Otherwise, the post should be neutral.

- Author Archives
  - If the author has a primary brand set, visit the author's archive (e.g. `/author/author‑name`) and verify that the author's primary brand is used.
  - Append `?brand=brand‑a` or any other brand slug that is not the primary for the author and reload.
  - Verify that the author's primary brand is still used (the override is ignored).
  - If the author does not have a primary brand, visit the author's archive and append `?brand=brand‑a` or any other valid brand slug.
  - Verify that the override (`brand‑a`) is used.

- Term Archives (Categories/Tags)
  - If your term (or an ancestor) has a primary brand set, visit the term's archive (e.g. `/category/my‑cat`) and verify that the primary brand (or ancestor's primary brand) is used.
  - Append `?brand=brand‑a` or any other brand slug that is not the primary for the category and reload.
  - Verify that the primary brand (or ancestor's primary) is still used (the override is ignored).
  - If your term (and its ancestors) do not have a primary brand, visit the term's archive and append `?brand=brand‑a` or any other valid brand slug.
  - Verify that the override (`brand‑a`) is used.

- Brand Archives
  - Visit a brand archive (e.g. `/brand‑a`) and verify that the brand (`brand‑a`) is used.
  - Append `?brand=brand‑b` (or any other brand slug) and reload.
  - Verify that the brand (`brand‑a`) is still used (the override is ignored).

- Homepage
  - Visit the homepage (e.g. `/`) and verify that the page is neutral (no brand is used).
  - Append `?brand=brand‑a` (or any other brand slug) and reload.
  - Verify that the homepage remains neutral (i.e. the override is ignored).

- Custom Override (Filter)
  - Add a custom filter that hooks into the `newspack_brand_override` and verify that the filter's logic (for example, overriding with a different brand or returning null) is applied as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?