### PR TITLE
feat: add frontend link rewriter to propagate brand parameter

### DIFF
--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -18,6 +18,7 @@ class Initializer {
 	public static function init() {
 		Taxonomy::init();
 		Admin::init();
+		Link_Rewriter::init();
 
 		Customizations\Url::init();
 		Customizations\Show_Page_On_Front::init();

--- a/includes/class-link-rewriter.php
+++ b/includes/class-link-rewriter.php
@@ -41,5 +41,19 @@ class Link_Rewriter {
 			filemtime( NEWSPACK_MULTIBRANDED_SITE_PLUGIN_DIR . '/dist/linkRewriter.js' ),
 			true
 		);
+
+		// Expose the current brand slug to JS via wp_localize_script.
+		$current_brand = null;
+		if ( class_exists( '\\Newspack_Multibranded_Site\\Taxonomy' ) && method_exists( '\\Newspack_Multibranded_Site\\Taxonomy', 'get_current' ) ) {
+			$brand = \Newspack_Multibranded_Site\Taxonomy::get_current();
+			if ( $brand instanceof \WP_Term ) {
+				$current_brand = $brand->slug;
+			}
+		}
+		wp_localize_script(
+			'newspack-link-rewriter',
+			'newspackBrandData',
+			[ 'current' => $current_brand ]
+		);
 	}
 }

--- a/includes/class-link-rewriter.php
+++ b/includes/class-link-rewriter.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Newspack Multibranded Site Link Rewriter.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Multibranded_Site;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class to handle frontend link rewriting.
+ */
+class Link_Rewriter {
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
+	}
+
+	/**
+	 * Enqueue the frontend script.
+	 */
+	public static function enqueue_scripts() {
+		// Only enqueue if we're on the frontend and not in the admin.
+		if ( is_admin() ) {
+			return;
+		}
+
+		// Enqueue WordPress dependencies.
+		wp_enqueue_script( 'wp-dom-ready' );
+		wp_enqueue_script( 'wp-url' );
+
+		wp_enqueue_script(
+			'newspack-link-rewriter',
+			plugins_url( '../dist/linkRewriter.js', __FILE__ ),
+			[ 'wp-dom-ready', 'wp-url' ],
+			filemtime( NEWSPACK_MULTIBRANDED_SITE_PLUGIN_DIR . '/dist/linkRewriter.js' ),
+			true
+		);
+	}
+}

--- a/src/link-rewriter/index.js
+++ b/src/link-rewriter/index.js
@@ -7,14 +7,38 @@
 import domReady from '@wordpress/dom-ready';
 import { addQueryArgs } from '@wordpress/url';
 
+// LocalStorage key for preferred brand.
+const PREFERRED_BRAND_KEY = 'np_preferred_brand';
+
 /**
- * Get the current brand from the URL.
+ * Get the current brand from the URL, localized data, or localStorage.
  *
  * @return {string|null} The brand slug or null if not present.
  */
 const getCurrentBrand = () => {
-	const urlParams = new URLSearchParams( window.location.search );
-	return urlParams.get( 'brand' );
+	const urlParams = new URLSearchParams(window.location.search);
+	if (urlParams.get('brand')) {
+		return urlParams.get('brand');
+	}
+	if (window.newspackBrandData?.current) {
+		return window.newspackBrandData.current;
+	}
+	return localStorage.getItem(PREFERRED_BRAND_KEY);
+};
+
+/**
+ * Persist the current brand from localized data in localStorage, if not already set.
+ */
+const persistBrandPreference = () => {
+	if (
+		window.newspackBrandData?.current &&
+		!localStorage.getItem(PREFERRED_BRAND_KEY)
+	) {
+		localStorage.setItem(
+			PREFERRED_BRAND_KEY,
+			window.newspackBrandData.current
+		);
+	}
 };
 
 /**
@@ -23,11 +47,17 @@ const getCurrentBrand = () => {
  * @param {string} url The URL to check.
  * @return {boolean} Whether the URL is internal.
  */
-const isInternalUrl = ( url ) => {
+const isInternalUrl = url => {
 	try {
-		const urlObj = new URL( url, window.location.origin );
+		const urlObj = new URL(url, window.location.origin);
+
+		// Ignore links that go directly to the main homepage or start with /wp-admin.
+		if (urlObj.pathname === '/' || urlObj.pathname.startsWith('/wp-admin')) {
+			return false;
+		}
+
 		return urlObj.hostname === window.location.hostname;
-	} catch ( e ) {
+	} catch (e) {
 		// If URL parsing fails, assume it's not internal.
 		return false;
 	}
@@ -39,11 +69,11 @@ const isInternalUrl = ( url ) => {
  * @param {string} url The URL to check.
  * @return {boolean} Whether the URL has a brand parameter.
  */
-const hasBrandParam = ( url ) => {
+const hasBrandParam = url => {
 	try {
-		const urlObj = new URL( url, window.location.origin );
-		return urlObj.searchParams.has( 'brand' );
-	} catch ( e ) {
+		const urlObj = new URL(url, window.location.origin);
+		return urlObj.searchParams.has('brand');
+	} catch (e) {
 		return false;
 	}
 };
@@ -55,10 +85,10 @@ const hasBrandParam = ( url ) => {
  * @param {string} brand The brand slug.
  * @return {string} The rewritten URL.
  */
-const rewriteUrl = ( url, brand ) => {
+const rewriteUrl = (url, brand) => {
 	try {
-		return addQueryArgs( url, { brand } );
-	} catch ( e ) {
+		return addQueryArgs(url, { brand });
+	} catch (e) {
 		return url;
 	}
 };
@@ -67,23 +97,25 @@ const rewriteUrl = ( url, brand ) => {
  * Initialize the link rewriter.
  */
 const initLinkRewriter = () => {
+	persistBrandPreference();
+
 	const brand = getCurrentBrand();
-	if ( ! brand ) {
+	if (!brand) {
 		return;
 	}
 
 	// Find all anchor tags in the document.
-	const links = document.getElementsByTagName( 'a' );
-	for ( const link of links ) {
-		const href = link.getAttribute( 'href' );
-		if ( ! href || ! isInternalUrl( href ) || hasBrandParam( href ) ) {
+	const links = document.getElementsByTagName('a');
+	for (const link of links) {
+		const href = link.getAttribute('href');
+		if (!href || !isInternalUrl(href) || hasBrandParam(href)) {
 			continue;
 		}
 
 		// Rewrite the URL to include the brand parameter.
-		link.setAttribute( 'href', rewriteUrl( href, brand ) );
+		link.setAttribute('href', rewriteUrl(href, brand));
 	}
 };
 
 // Initialize when the DOM is ready.
-domReady( initLinkRewriter );
+domReady(initLinkRewriter);

--- a/src/link-rewriter/index.js
+++ b/src/link-rewriter/index.js
@@ -1,0 +1,89 @@
+/**
+ * Newspack Multibranded Site Link Rewriter.
+ *
+ * Rewrites internal links to include the current brand parameter.
+ */
+
+import domReady from '@wordpress/dom-ready';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Get the current brand from the URL.
+ *
+ * @return {string|null} The brand slug or null if not present.
+ */
+const getCurrentBrand = () => {
+	const urlParams = new URLSearchParams( window.location.search );
+	return urlParams.get( 'brand' );
+};
+
+/**
+ * Check if a URL is internal to the current site.
+ *
+ * @param {string} url The URL to check.
+ * @return {boolean} Whether the URL is internal.
+ */
+const isInternalUrl = ( url ) => {
+	try {
+		const urlObj = new URL( url, window.location.origin );
+		return urlObj.hostname === window.location.hostname;
+	} catch ( e ) {
+		// If URL parsing fails, assume it's not internal.
+		return false;
+	}
+};
+
+/**
+ * Check if a URL already has a brand parameter.
+ *
+ * @param {string} url The URL to check.
+ * @return {boolean} Whether the URL has a brand parameter.
+ */
+const hasBrandParam = ( url ) => {
+	try {
+		const urlObj = new URL( url, window.location.origin );
+		return urlObj.searchParams.has( 'brand' );
+	} catch ( e ) {
+		return false;
+	}
+};
+
+/**
+ * Rewrite a URL to include the brand parameter.
+ *
+ * @param {string} url   The URL to rewrite.
+ * @param {string} brand The brand slug.
+ * @return {string} The rewritten URL.
+ */
+const rewriteUrl = ( url, brand ) => {
+	try {
+		return addQueryArgs( url, { brand } );
+	} catch ( e ) {
+		return url;
+	}
+};
+
+/**
+ * Initialize the link rewriter.
+ */
+const initLinkRewriter = () => {
+	const brand = getCurrentBrand();
+	if ( ! brand ) {
+		return;
+	}
+
+	// Find all anchor tags in the document.
+	const links = document.getElementsByTagName( 'a' );
+	for ( const link of links ) {
+		const href = link.getAttribute( 'href' );
+		if ( ! href || ! isInternalUrl( href ) || hasBrandParam( href ) ) {
+			continue;
+		}
+
+		// Rewrite the URL to include the brand parameter.
+		link.setAttribute( 'href', rewriteUrl( href, brand ) );
+	}
+};
+
+// Initialize when the DOM is ready.
+domReady( initLinkRewriter );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,11 +17,16 @@ const entry = {
 	admin: path.join( __dirname, 'src/admin' ),
 	postPrimaryBrand: path.join( __dirname, 'src/post-primary-brand' ),
 	promptBrands: path.join( __dirname, 'src/prompt-brands' ),
+	linkRewriter: path.join( __dirname, 'src/link-rewriter' ),
 };
 
 const webpackConfig = getBaseWebpackConfig(
 	{
 		entry,
+		externals: {
+			'@wordpress/dom-ready': 'wp.domReady',
+			'@wordpress/url': 'wp.url',
+		},
 	}
 );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

- Add `Link_Rewriter` class to enqueue a frontend script that rewrites internal links.
- Add new `link-rewriter/index.js` script:
  - Detects current brand from URL (`?brand=brand-slug`).
  - Rewrites all internal anchor tags to include the brand parameter if not already present.
  - Skips external links and links that already have a brand parameter.
- Register and enqueue the script via `Link_Rewriter::init()` in `Initializer`.
- Update webpack config to bundle `linkRewriter` and provide WordPress externals.

This helps preserve brand context through links as users navigate the site.

### How to test the changes in this Pull Request:
1. Verify that the Link Rewriter is initialized and its script is enqueued on the frontend.
2. Verify that internal links on a page with a brand override are rewritten.
    - Visit a public page (for example, a post or an archive) and append `?brand=brand‑a` (or a valid brand slug) to the URL.
    - Inspect the page (using your browser's dev tools) and locate internal anchor tags (for example, a link to another post or a category).
    - Confirm that the `href` attribute of these internal links is rewritten (i.e. `?brand=brand‑a` is appended).
2. Verify that links that are not internal are not rewritten.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?