### PR TITLE
chore: update changelog workflow to run on release branch

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,2 @@
 needs-changelog:
- - base-branch: ['trunk']
+ - base-branch: ['trunk', 'release']

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   labeler:
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'trunk' && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.event.pull_request.merged == true && (github.event.pull_request.base.ref == 'trunk' || github.event.pull_request.base.ref == 'release') && github.event.pull_request.user.login != 'dependabot[bot]'
     permissions:
       contents: read
       pull-requests: write
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/labeler@v5
 
   comment_pr:
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'trunk' && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.event.pull_request.merged == true && (github.event.pull_request.base.ref == 'trunk' || github.event.pull_request.base.ref == 'release') && github.event.pull_request.user.login != 'dependabot[bot]'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- Updated changelog workflow to also execute on merges to the release branch

## Changes
- Modified the `if` conditions in both `labeler` and `comment_pr` jobs to include `release` branch in addition to `trunk`
- This ensures the changelog labeling and PR commenting happens for both trunk and release branch merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)