### PR TITLE
fix: resolve brand taxonomy URL conflict with WooCommerce product_brand

### DIFF
--- a/includes/customizations/class-url.php
+++ b/includes/customizations/class-url.php
@@ -26,10 +26,93 @@ class Url {
 	/**
 	 * Parse the request
 	 *
+	 * Handles two URL modes for brands:
+	 * - "Homepage" mode (_custom_url=yes): brand at site root, e.g. /sports/
+	 * - "Default" mode (_custom_url=no): brand under /brand/ prefix, e.g. /brand/lifestyle/
+	 *
+	 * The "Default" mode requires special handling because other plugins (e.g.
+	 * WooCommerce) may register taxonomies with the same "brand" rewrite slug,
+	 * causing their rewrite rules to capture /brand/{slug}/ requests. This method
+	 * detects when a request was matched to a conflicting taxonomy and re-routes
+	 * it to our brand taxonomy when appropriate.
+	 *
 	 * @param WP $wp The WP object.
 	 * @return void
 	 */
 	public static function parse_request( $wp ) {
+		// Handle "Default" mode: detect /brand/{slug}/ captured by a conflicting taxonomy.
+		self::maybe_resolve_rewrite_conflict( $wp );
+
+		// Handle "Homepage" mode: detect brand slugs at the site root.
+		self::maybe_resolve_root_brand( $wp );
+	}
+
+	/**
+	 * Resolve rewrite conflicts for the "Default" URL mode.
+	 *
+	 * When another taxonomy shares the "brand" rewrite slug, its rewrite rules
+	 * capture /brand/{slug}/ requests. This checks if the matched slug is
+	 * actually a brand term in our taxonomy and re-routes accordingly.
+	 *
+	 * @param WP $wp The WP object.
+	 * @return void
+	 */
+	private static function maybe_resolve_rewrite_conflict( $wp ) {
+		$matched_query = wp_parse_args( $wp->matched_query );
+
+		// Find any query var from a taxonomy whose rewrite slug is "brand".
+		$conflicting_slug = self::get_conflicting_brand_slug( $matched_query );
+		if ( ! $conflicting_slug ) {
+			return;
+		}
+
+		$term = get_term_by( 'slug', $conflicting_slug, Taxonomy::SLUG );
+		if ( ! $term instanceof \WP_Term ) {
+			return;
+		}
+
+		// Remove the conflicting taxonomy's query var and set ours.
+		foreach ( $wp->query_vars as $key => $value ) {
+			if ( $value === $conflicting_slug && $key !== Taxonomy::SLUG ) {
+				unset( $wp->query_vars[ $key ] );
+			}
+		}
+		$wp->query_vars[ Taxonomy::SLUG ] = $term->slug;
+	}
+
+	/**
+	 * Get the brand slug from a query matched by a conflicting taxonomy.
+	 *
+	 * Checks all registered taxonomies for any that use "brand" as their rewrite
+	 * slug (other than our own) and returns the matched term slug if found.
+	 *
+	 * @param array $matched_query The parsed matched query args.
+	 * @return string|null The matched slug, or null if no conflict.
+	 */
+	private static function get_conflicting_brand_slug( $matched_query ) {
+		$taxonomies = get_taxonomies( [ 'public' => true ], 'objects' );
+		foreach ( $taxonomies as $taxonomy ) {
+			if ( Taxonomy::SLUG === $taxonomy->name ) {
+				continue;
+			}
+			$rewrite_slug = isset( $taxonomy->rewrite['slug'] ) ? $taxonomy->rewrite['slug'] : $taxonomy->name;
+			if ( Taxonomy::SLUG !== $rewrite_slug ) {
+				continue;
+			}
+			if ( ! empty( $matched_query[ $taxonomy->query_var ] ) ) {
+				return $matched_query[ $taxonomy->query_var ];
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Resolve brand slugs at the site root ("Homepage" URL mode).
+	 *
+	 * @param WP $wp The WP object.
+	 * @return void
+	 */
+	private static function maybe_resolve_root_brand( $wp ) {
 		$matched_query = wp_parse_args( $wp->matched_query );
 
 		if ( empty( $matched_query['pagename'] ) && empty( $matched_query['name'] ) ) {
@@ -42,7 +125,7 @@ class Url {
 			array(
 				'taxonomy'   => Taxonomy::SLUG,
 				'hide_empty' => false,
-				'meta_key'   => Url_Meta::get_key(), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'meta_key'   => Url_Meta::get_key(), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_value' => 'yes', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 			)
 		);

--- a/includes/customizations/class-url.php
+++ b/includes/customizations/class-url.php
@@ -71,6 +71,13 @@ class Url {
 			return;
 		}
 
+		// Skip brands configured for root URL mode — they live at /{slug}/, not
+		// /brand/{slug}/, so we should not claim the /brand/ path for them.
+		$custom_url = get_term_meta( $term->term_id, Url_Meta::get_key(), true );
+		if ( 'yes' === $custom_url ) {
+			return;
+		}
+
 		// Remove the conflicting taxonomy's query var and set ours.
 		foreach ( $wp->query_vars as $key => $value ) {
 			if ( $value === $conflicting_slug && $key !== Taxonomy::SLUG ) {

--- a/includes/customizations/class-url.php
+++ b/includes/customizations/class-url.php
@@ -99,10 +99,15 @@ class Url {
 			if ( Taxonomy::SLUG === $taxonomy->name ) {
 				continue;
 			}
-			$rewrite_slug = is_array( $taxonomy->rewrite ) && isset( $taxonomy->rewrite['slug'] )
-				? $taxonomy->rewrite['slug']
-				: $taxonomy->name;
+			// Skip taxonomies without rewrite rules — they cannot conflict with /brand/.
+			if ( ! is_array( $taxonomy->rewrite ) ) {
+				continue;
+			}
+			$rewrite_slug = $taxonomy->rewrite['slug'] ?? $taxonomy->name;
 			if ( Taxonomy::SLUG !== $rewrite_slug ) {
+				continue;
+			}
+			if ( empty( $taxonomy->query_var ) ) {
 				continue;
 			}
 			if ( ! empty( $matched_query[ $taxonomy->query_var ] ) ) {

--- a/includes/customizations/class-url.php
+++ b/includes/customizations/class-url.php
@@ -60,13 +60,13 @@ class Url {
 	private static function maybe_resolve_rewrite_conflict( $wp ) {
 		$matched_query = wp_parse_args( $wp->matched_query );
 
-		// Find any query var from a taxonomy whose rewrite slug is "brand".
-		$conflicting_slug = self::get_conflicting_brand_slug( $matched_query );
-		if ( ! $conflicting_slug ) {
+		// Find the query var and slug from a taxonomy whose rewrite slug is "brand".
+		$conflict = self::get_conflicting_brand_query_var( $matched_query );
+		if ( ! $conflict ) {
 			return;
 		}
 
-		$term = get_term_by( 'slug', $conflicting_slug, Taxonomy::SLUG );
+		$term = get_term_by( 'slug', $conflict['slug'], Taxonomy::SLUG );
 		if ( ! $term instanceof \WP_Term ) {
 			return;
 		}
@@ -78,36 +78,38 @@ class Url {
 			return;
 		}
 
-		// Remove the conflicting taxonomy's query var and set ours.
-		foreach ( $wp->query_vars as $key => $value ) {
-			if ( $value === $conflicting_slug && $key !== Taxonomy::SLUG ) {
-				unset( $wp->query_vars[ $key ] );
-			}
-		}
+		// Remove the specific conflicting taxonomy's query var and set ours.
+		unset( $wp->query_vars[ $conflict['query_var'] ] );
 		$wp->query_vars[ Taxonomy::SLUG ] = $term->slug;
 	}
 
 	/**
-	 * Get the brand slug from a query matched by a conflicting taxonomy.
+	 * Get the query var and slug from a conflicting taxonomy match.
 	 *
 	 * Checks all registered taxonomies for any that use "brand" as their rewrite
-	 * slug (other than our own) and returns the matched term slug if found.
+	 * slug (other than our own) and returns the matched query var name and term
+	 * slug if found.
 	 *
 	 * @param array $matched_query The parsed matched query args.
-	 * @return string|null The matched slug, or null if no conflict.
+	 * @return array|null Array with 'query_var' and 'slug' keys, or null if no conflict.
 	 */
-	private static function get_conflicting_brand_slug( $matched_query ) {
+	private static function get_conflicting_brand_query_var( $matched_query ) {
 		$taxonomies = get_taxonomies( [ 'public' => true ], 'objects' );
 		foreach ( $taxonomies as $taxonomy ) {
 			if ( Taxonomy::SLUG === $taxonomy->name ) {
 				continue;
 			}
-			$rewrite_slug = isset( $taxonomy->rewrite['slug'] ) ? $taxonomy->rewrite['slug'] : $taxonomy->name;
+			$rewrite_slug = is_array( $taxonomy->rewrite ) && isset( $taxonomy->rewrite['slug'] )
+				? $taxonomy->rewrite['slug']
+				: $taxonomy->name;
 			if ( Taxonomy::SLUG !== $rewrite_slug ) {
 				continue;
 			}
 			if ( ! empty( $matched_query[ $taxonomy->query_var ] ) ) {
-				return $matched_query[ $taxonomy->query_var ];
+				return [
+					'query_var' => $taxonomy->query_var,
+					'slug'      => $matched_query[ $taxonomy->query_var ],
+				];
 			}
 		}
 		return null;

--- a/tests/unit-tests/test-customization-url.php
+++ b/tests/unit-tests/test-customization-url.php
@@ -32,4 +32,74 @@ class TestUrlCustomization extends WP_UnitTestCase {
 		$this->assertTrue( is_tax() );
 		$this->assertSame( $term_with_custom_url->term_id, get_queried_object_id() );
 	}
+
+	/**
+	 * Tests that the default URL mode resolves when a conflicting taxonomy has
+	 * captured the rewrite rule for /brand/{slug}/.
+	 */
+	public function test_parse_request_resolves_rewrite_conflict() {
+		// Register a conflicting taxonomy with "brand" as its rewrite slug,
+		// simulating WooCommerce's product_brand taxonomy.
+		register_taxonomy(
+			'test_product_brand',
+			'product',
+			[
+				'public'    => true,
+				'rewrite'   => [ 'slug' => 'brand' ],
+				'query_var' => 'test_product_brand',
+			]
+		);
+
+		$brand = $this->factory->term->create_and_get( [ 'taxonomy' => Taxonomy::SLUG ] );
+
+		$this->set_permalink_structure( '/%postname%/' );
+
+		// Simulate what happens when /brand/{slug}/ is matched by the
+		// conflicting taxonomy's rewrite rule: WP sets the conflicting
+		// taxonomy's query var to the slug.
+		global $wp;
+		$wp->matched_query = 'test_product_brand=' . $brand->slug;
+		$wp->query_vars    = [ 'test_product_brand' => $brand->slug ];
+
+		// Run parse_request — this should detect the conflict and re-route.
+		Newspack_Multibranded_Site\Customizations\Url::parse_request( $wp );
+
+		$this->assertArrayHasKey( Taxonomy::SLUG, $wp->query_vars, 'Brand query var should be set.' );
+		$this->assertSame( $brand->slug, $wp->query_vars[ Taxonomy::SLUG ] );
+		$this->assertArrayNotHasKey( 'test_product_brand', $wp->query_vars, 'Conflicting query var should be removed.' );
+
+		// Clean up.
+		unregister_taxonomy( 'test_product_brand' );
+	}
+
+	/**
+	 * Tests that the conflict resolver does not interfere when the slug does
+	 * not match any brand term.
+	 */
+	public function test_parse_request_no_false_positive_on_conflict() {
+		register_taxonomy(
+			'test_product_brand',
+			'product',
+			[
+				'public'    => true,
+				'rewrite'   => [ 'slug' => 'brand' ],
+				'query_var' => 'test_product_brand',
+			]
+		);
+
+		$this->set_permalink_structure( '/%postname%/' );
+
+		// Simulate a request for a slug that is NOT a brand term.
+		global $wp;
+		$wp->matched_query = 'test_product_brand=nike';
+		$wp->query_vars    = [ 'test_product_brand' => 'nike' ];
+
+		Newspack_Multibranded_Site\Customizations\Url::parse_request( $wp );
+
+		$this->assertArrayNotHasKey( Taxonomy::SLUG, $wp->query_vars, 'Brand query var should not be set for non-brand slugs.' );
+		$this->assertSame( 'nike', $wp->query_vars['test_product_brand'], 'Conflicting query var should remain for non-brand slugs.' );
+
+		// Clean up.
+		unregister_taxonomy( 'test_product_brand' );
+	}
 }

--- a/tests/unit-tests/test-customization-url.php
+++ b/tests/unit-tests/test-customization-url.php
@@ -108,6 +108,23 @@ class TestUrlCustomization extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that parse_request is a no-op when no other taxonomy with the
+	 * "brand" rewrite slug is registered (the common case).
+	 */
+	public function test_parse_request_no_op_without_conflict() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		global $wp;
+		$wp->matched_query = 'pagename=about';
+		$wp->query_vars    = [ 'pagename' => 'about' ];
+
+		Newspack_Multibranded_Site\Customizations\Url::parse_request( $wp );
+
+		$this->assertArrayNotHasKey( Taxonomy::SLUG, $wp->query_vars, 'Brand var should not be set without a conflict.' );
+		$this->assertSame( 'about', $wp->query_vars['pagename'], 'Existing query vars should be untouched.' );
+	}
+
+	/**
 	 * Tests that homepage-mode brands (_custom_url=yes) are not claimed at
 	 * /brand/{slug}/ — they live at the site root instead.
 	 */

--- a/tests/unit-tests/test-customization-url.php
+++ b/tests/unit-tests/test-customization-url.php
@@ -14,6 +14,16 @@ use Newspack_Multibranded_Site\Meta\Url as Url_Meta;
 class TestUrlCustomization extends WP_UnitTestCase {
 
 	/**
+	 * Clean up the conflicting taxonomy after each test so it never leaks.
+	 */
+	public function tearDown(): void {
+		if ( taxonomy_exists( 'test_product_brand' ) ) {
+			unregister_taxonomy( 'test_product_brand' );
+		}
+		parent::tearDown();
+	}
+
+	/**
 	 * Tests get current brand and determine current brand methods
 	 */
 	public function test_parse_request() {
@@ -67,9 +77,6 @@ class TestUrlCustomization extends WP_UnitTestCase {
 		$this->assertArrayHasKey( Taxonomy::SLUG, $wp->query_vars, 'Brand query var should be set.' );
 		$this->assertSame( $brand->slug, $wp->query_vars[ Taxonomy::SLUG ] );
 		$this->assertArrayNotHasKey( 'test_product_brand', $wp->query_vars, 'Conflicting query var should be removed.' );
-
-		// Clean up.
-		unregister_taxonomy( 'test_product_brand' );
 	}
 
 	/**
@@ -98,9 +105,6 @@ class TestUrlCustomization extends WP_UnitTestCase {
 
 		$this->assertArrayNotHasKey( Taxonomy::SLUG, $wp->query_vars, 'Brand query var should not be set for non-brand slugs.' );
 		$this->assertSame( 'nike', $wp->query_vars['test_product_brand'], 'Conflicting query var should remain for non-brand slugs.' );
-
-		// Clean up.
-		unregister_taxonomy( 'test_product_brand' );
 	}
 
 	/**
@@ -133,8 +137,5 @@ class TestUrlCustomization extends WP_UnitTestCase {
 		// The brand has _custom_url=yes, so it should NOT be claimed at /brand/.
 		$this->assertArrayNotHasKey( Taxonomy::SLUG, $wp->query_vars, 'Homepage-mode brand should not be claimed at /brand/ path.' );
 		$this->assertSame( $brand->slug, $wp->query_vars['test_product_brand'], 'Conflicting query var should remain for homepage-mode brands.' );
-
-		// Clean up.
-		unregister_taxonomy( 'test_product_brand' );
 	}
 }

--- a/tests/unit-tests/test-customization-url.php
+++ b/tests/unit-tests/test-customization-url.php
@@ -102,4 +102,39 @@ class TestUrlCustomization extends WP_UnitTestCase {
 		// Clean up.
 		unregister_taxonomy( 'test_product_brand' );
 	}
+
+	/**
+	 * Tests that homepage-mode brands (_custom_url=yes) are not claimed at
+	 * /brand/{slug}/ — they live at the site root instead.
+	 */
+	public function test_parse_request_skips_homepage_mode_brands() {
+		register_taxonomy(
+			'test_product_brand',
+			'product',
+			[
+				'public'    => true,
+				'rewrite'   => [ 'slug' => 'brand' ],
+				'query_var' => 'test_product_brand',
+			]
+		);
+
+		$brand = $this->factory->term->create_and_get( [ 'taxonomy' => Taxonomy::SLUG ] );
+		add_term_meta( $brand->term_id, Url_Meta::get_key(), 'yes' );
+
+		$this->set_permalink_structure( '/%postname%/' );
+
+		// Simulate /brand/{slug}/ captured by the conflicting taxonomy.
+		global $wp;
+		$wp->matched_query = 'test_product_brand=' . $brand->slug;
+		$wp->query_vars    = [ 'test_product_brand' => $brand->slug ];
+
+		Newspack_Multibranded_Site\Customizations\Url::parse_request( $wp );
+
+		// The brand has _custom_url=yes, so it should NOT be claimed at /brand/.
+		$this->assertArrayNotHasKey( Taxonomy::SLUG, $wp->query_vars, 'Homepage-mode brand should not be claimed at /brand/ path.' );
+		$this->assertSame( $brand->slug, $wp->query_vars['test_product_brand'], 'Conflicting query var should remain for homepage-mode brands.' );
+
+		// Clean up.
+		unregister_taxonomy( 'test_product_brand' );
+	}
 }


### PR DESCRIPTION
## Changes proposed

Fixes `/brand/{slug}/` returning 404 when WooCommerce is active. 

WooCommerce's `product_brand` taxonomy registers with rewrite slug `brand`, shadowing our `brand` taxonomy's rewrite rules. 

The fix extends the existing `parse_request` handler to detect when a conflicting taxonomy has captured a `/brand/{slug}/` request and re-routes it to the `brand` taxonomy when the slug matches a brand term.

- Refactored `Url::parse_request()` into two clear paths: `maybe_resolve_rewrite_conflict()` for "Default" URL mode and `maybe_resolve_root_brand()` for "Homepage" URL mode
- Brands with `_custom_url=yes` (root mode) are excluded from the conflict resolver — they live at `/{slug}/`, not `/brand/{slug}/`
- Uses targeted `unset()` on the specific conflicting query var rather than a broad loop
- Fixed PHPCS ignore comment (`slow_db_query_meta_value` → `slow_db_query_meta_key`)

Fixes [NPPM-2734: Multibranded site /brand/slug route not working](https://linear.app/a8c/issue/NPPM-2734/multibranded-site-brandslug-route-not-working) and solves a real head-scratcher when my test site with Woo installed didn't behave as expected.

## How to test

1. On `trunk` (before applying this PR):
   - Activate WooCommerce and Newspack Multibranded Site
   - Flush permalinks (Settings > Permalinks > Save)
   - Create a brand with "Default" URL base (e.g., "Lifestyle")
   - Visit `/brand/lifestyle/` — observe 404
2. Apply this PR, then:
   - Visit `/brand/lifestyle/` — should now return the brand archive
   - Create a brand with "Homepage" URL base (e.g., "Sports")
   - Visit `/sports/` — should return 200 (root mode unaffected)
   - Visit `/brand/nonexistent/` — should return 404 (no false positive)


---

**Cross-repo impact review:** no shared-contract files changed — change is local to this repo.