### PR TITLE
feat(access-control): enable Brand taxonomy for content rules

### DIFF
--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -29,5 +29,6 @@ class Initializer {
 		Customizations\Body_Class::init();
 		Customizations\Site_Title::init();
 		Integrations\Google_Analytics::init();
+		Integrations\Access_Control::init();
 	}
 }

--- a/includes/integrations/class-access-control.php
+++ b/includes/integrations/class-access-control.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Newspack Multibranded - Access Control integration.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Multibranded_Site\Integrations;
+
+use Newspack_Multibranded_Site\Taxonomy;
+
+/**
+ * Class to handle the Access Control integration.
+ */
+class Access_Control {
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_filter( 'newspack_content_gate_supported_taxonomies', array( __CLASS__, 'add_brand_content_rule' ) );
+	}
+
+	/**
+	 * Add brand taxonomy as an Access Control content rule.
+	 *
+	 * @param array $available_taxonomies Array of taxonomies.
+	 *
+	 * @return array
+	 */
+	public static function add_brand_content_rule( $available_taxonomies ) {
+		if ( ! in_array( Taxonomy::SLUG, array_column( $available_taxonomies, 'slug' ), true ) ) {
+			$available_taxonomies[] = array(
+				'slug'        => Taxonomy::SLUG,
+				'label'       => __( 'Brands', 'newspack-multibranded-site' ),
+				'description' => __( 'Content within specific brands.', 'newspack-multibranded-site' ),
+			);
+		}
+
+		return $available_taxonomies;
+	}
+}


### PR DESCRIPTION
Adds the "Brand" taxonomy as a content rule for Newspack Access Control.

Closes NPPD-1554.

## Testing

**Prerequisites:**

- `NEWSPACK_CONTENT_GATES` defined in wp-config.php
- WooCommerce Memberships plugin NOT active
- Multibranded Sites plugin active with at least one brand configured and assigned to specific posts

1. In **Audience > Access Control**, edit or create a content gate.
2. Under "What would you like to restrict?" select "Choose specific content" and confirm you see the "Brand" option:

<img width="479" height="203" alt="Screenshot 2026-05-26 at 4 27 27 PM" src="https://github.com/user-attachments/assets/8b2a0aba-5fc3-477b-86b6-3359dbd4cb01" />

3. Confirm that you can search for and select your brands. Choose one or more, leave all other content rules inactive, then add Registered and/or Paid access rules and save. Confirm that the brand selection persists after a refresh.
4. On the front-end, visit a post assigned to the selected brand. Confirm that content gate restrictions apply to the post, but not to posts that aren't assigned to the brand.